### PR TITLE
Lra 521 lsa ride share add google fonts and scss stylesheet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+gem 'dartsass-rails', '~> 0.4.1'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
+    dartsass-rails (0.4.1)
+      railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -271,6 +273,7 @@ DEPENDENCIES
   annotate (~> 3.2)
   bootsnap
   capybara
+  dartsass-rails (~> 0.4.1)
   debug
   devise
   factory_bot_rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails tailwindcss:watch
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,87 @@
+// Sassy
+/* the switch toggle was influenced by https://codepen.io/tutsplus/pen/qBOjjvO */
+
+.switches {
+  [type="checkbox"] {
+    position: absolute;
+    left: -9999px;
+
+    max-width: 150px;
+    width: 95%;
+    margin: 20px auto 0;
+    border-radius: 5px;
+    color: white;
+    background: RoyalBlue;
+  }
+  li {
+    position: relative;
+    counter-increment: switchCounter;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid gray;
+    }
+  }
+  .label-text {
+    padding-right: 2px;
+  }
+  label {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px 8px 10px;
+  }
+  span:last-child {
+    position: relative;
+    width: 50px;
+    height:30px;
+    border-radius: 15px;
+    box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.4);
+    background: gray;
+    transition: all 0.3s;
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+    }
+    &::before {
+      left: 4px;
+      top: 4px;
+      width: 20px;
+      height: 20px;
+      background: white;
+      border-radius: 50%;
+      z-index: 1;
+      transition: transform 0.3s;
+    }
+    &::after {
+      top: 50%;
+      right: 8px;
+      width: 12px;
+      height: 12px;
+      transform: translateY(-50%);
+      background: url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/162656/uncheck-switcher.svg);
+      background-size: 12px 12px;
+    }
+  }
+  [type="checkbox"]:checked + label span:last-child {
+    background: green;
+
+    &::before {
+      transform: translateX(24px);
+    }
+    &::after {
+      width: 14px;
+      height: 14px;
+      left: 8px;
+      background-image: url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/162656/checkmark-switcher.svg);
+      background-size: 14px 14px;
+    }
+  }
+}
+@media screen and (max-width: 600px) {
+  .switches li::before {
+    display: none;
+  }
+};

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,7 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&family=Oswald:wght@400;500;600&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import 'actiontext.css';
 
 /*
 
@@ -16,11 +16,7 @@ from https://tailwindcss.com/docs/adding-custom-styles
 
 @layer base {
   .header_link {
-    @apply border-transparent text-blue-50 inline-flex items-center pr-1 pt-1 border-b-2 text-base font-normal
-  }
-
-  .header_link:hover {
-    @apply border-blue-300 text-white
+    @apply border-transparent text-blue-50 inline-flex items-center pr-1 pt-1 border-b-2 text-base font-normal hover:border-blue-300 text-white
   }
 
   .active {
@@ -28,31 +24,55 @@ from https://tailwindcss.com/docs/adding-custom-styles
   }
 
   h1 {
-    @apply text-3xl font-semibold leading-10 font-oswald;
+    @apply text-4xl font-semibold leading-normal font-oswald;
   }
 
   h2 {
-    @apply text-2xl font-semibold leading-9 font-oswald;
+    @apply text-3xl font-medium leading-10 font-oswald;
   }
 
   h3 {
-    @apply text-lg font-semibold leading-7 font-oswald;
+    @apply text-xl font-medium leading-8 font-oswald;
   }
 
   h4 {
-    @apply text-base font-normal leading-6 font-oswald;
+    @apply text-base font-medium leading-6 font-oswald;
   }
 
   h5 {
-    @apply text-sm font-normal leading-5 font-oswald;
+    @apply text-base font-normal leading-6 font-oswald;
   }
 
   h6 {
-    @apply text-xs font-normal leading-4 font-oswald;
+    @apply text-sm font-medium leading-5 font-oswald;
+  }
+
+  hr {
+    @apply border-blue-900 border m-4
   }
 
   .body-text {
-    @apply text-xs font-medium leading-4;
+    @apply text-xs font-normal leading-4 font-montserrat;
+  }
+
+  .body-bold-text {
+    @apply text-xs font-medium leading-4 font-montserrat;
+  }
+
+  .body-md-text {
+    @apply text-sm font-normal leading-5 font-montserrat;
+  }
+
+  .body-md-bold-text {
+    @apply text-sm font-medium leading-5 font-montserrat;
+  }
+
+  .body-lg-text {
+    @apply text-base font-normal leading-6 font-montserrat;
+  }
+
+  .body-lg-bold-text {
+    @apply text-base font-bold leading-6 font-montserrat;
   }
 
   .button_label {
@@ -75,34 +95,131 @@ from https://tailwindcss.com/docs/adding-custom-styles
     @apply ml-2 text-sm text-gray-700
   }
 
-  .edit_button {
-    @apply my-2 px-2 py-1 rounded-md shadow-sm bg-blue-umblue text-sm text-gray-100 text-center
+  .primary_button {
+    @apply p-2 font-montserrat font-semibold leading-7 text-base border rounded-md text-white bg-blue-umblue
   }
 
-  .edit_buton:hover {
+  .primary_button:hover {
+    @apply underline text-blue-umblue bg-white border-solid border-blue-umblue border-2
+  }
+
+  .primary_button:active {
+    @apply underline text-blue-umblue bg-white border-solid border-blue-umblue border-2
+  }
+
+  .primary_button:focus {
+    @apply underline text-blue-umblue bg-white border-solid border-blue-umblue border-2
+  }
+
+  .primary_button:disabled {
+    @apply opacity-50 bg-black pointer-events-none text-white
+  }
+
+  .secondary_yellow_button {
+    @apply p-2 font-montserrat font-semibold leading-7 text-base border rounded-md text-blue-umblue bg-yellow-ummaze
+  }
+
+  .secondary_yellow_button:hover {
+    @apply underline text-blue-umblue bg-white border-solid border-yellow-ummaze border-2
+  }
+
+  .secondary_yellow_button:active {
+    @apply underline text-blue-umblue bg-white border-solid border-yellow-ummaze border-2
+  }
+
+  .secondary_yellow_button:focus {
+    @apply underline text-blue-umblue bg-white border-solid border-yellow-ummaze border-2
+  }
+
+  .secondary_yellow_button:disabled {
+    @apply opacity-50 bg-black pointer-events-none text-white
+  }
+  
+  .secondary_blue_button {
+    @apply p-2 font-montserrat font-semibold leading-7 text-base border rounded-md text-white bg-blue-750
+  }
+
+  .secondary_blue_button:hover {
+    @apply underline text-blue-750 bg-white border-solid border-blue-750 border-2
+  }
+
+  .secondary_blue_button:active {
+    @apply underline text-blue-750 bg-white border-solid border-blue-750 border-2
+  }
+
+  .secondary_blue_button:focus {
+    @apply underline text-blue-750 bg-white border-solid border-blue-750 border-2
+  }
+
+  .secondary_blue_button:disabled {
+    @apply opacity-50 bg-black pointer-events-none text-white
+  }
+
+  .tertiary_button {
+    @apply p-2 font-montserrat font-semibold leading-7 text-base text-blue-umblue
+  }
+
+  .tertiary_button:hover {
     @apply underline
+  }
+
+  .tertiary_button:active {
+    @apply underline
+  }
+
+  .tertiary_button:focus {
+    @apply underline
+  }
+
+  .tertiary_button:disabled {
+    @apply text-opacity-50 pointer-events-none text-blue-umblue
+  }
+
+  .sign_button {
+    @apply px-1 shadow-sm text-base rounded text-blue-900 bg-yellow-550 bg-yellow-500 hover:underline
+  }
+
+  .edit_button {
+    @apply my-2 px-2 py-1 rounded-md shadow-sm bg-blue-umblue text-sm text-gray-100 text-center hover:underline
   }
 
   .back_button {
-    @apply flex items-center text-sm text-blue-umblue pb-2
-  }
-
-  .back_buton:hover {
-    @apply underline
+    @apply flex items-center text-sm text-blue-umblue pb-2 hover:underline
   }
 
   .delete_button {
-    @apply my-2 px-2 py-1 rounded-md shadow-sm bg-gray-100 text-sm text-blue-umblue text-center
-  }
-
-  .delete_buton:hover {
-    @apply underline
+    @apply my-2 px-2 py-1 rounded-md shadow-sm bg-gray-100 text-sm text-blue-umblue text-center hover:underline
   }
 
   .input_text_field {
-    @aply block shadow rounded-md border border-gray-200 outline-none
+    @apply text-lg font-medium text-gray-900 bg-white border border-gray-600 rounded block p-2 focus:ring-blue-500 focus:border-blue-500
   }
 
+  .fancy_label {
+    @apply text-sm font-bold text-gray-900 bg-white relative px-1 top-2 left-3 w-auto group-focus-within:text-red-600
+  }
+
+  /* table */
+
+  .mi_table {
+    @apply px-2 min-w-full divide-y;
+  }
+
+  .mi_thead {
+    @apply bg-gray-400
+  }
+
+  .header_th {
+    @apply p-2 text-sm font-semibold text-gray-900 lg:table-cell text-left
+  }
+
+  .mi_tbody_tr {
+    @apply relative sm:pl-2 text-sm bg-white even:bg-gray-200
+  }
+
+  .mi_tbody_td {
+    @apply relative p-2 sm:pl-2 text-sm font-medium text-gray-900 text-left
+  }
   /* ... */
 }
 

--- a/app/views/admin_accesses/edit.html.erb
+++ b/app/views/admin_accesses/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing admin access</h1>
+  <h1>Editing admin access</h1>
 
   <%= render "form", admin_access: @admin_access %>
 

--- a/app/views/admin_accesses/index.html.erb
+++ b/app/views/admin_accesses/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Admin accesses</h1>
+    <h1>Admin accesses</h1>
     <%= link_to 'New admin access', new_admin_access_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/admin_accesses/new.html.erb
+++ b/app/views/admin_accesses/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New admin access</h1>
+  <h1>New admin access</h1>
 
   <%= render "form", admin_access: @admin_access %>
 

--- a/app/views/cars/edit.html.erb
+++ b/app/views/cars/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing car</h1>
+  <h1>Editing car</h1>
 
   <%= render "form", car: @car %>
 

--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Cars</h1>
+    <h1>Cars</h1>
     <%= link_to 'New car', new_car_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/cars/new.html.erb
+++ b/app/views/cars/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New car</h1>
+  <h1>New car</h1>
 
   <%= render "form", car: @car %>
 

--- a/app/views/config_questions/edit.html.erb
+++ b/app/views/config_questions/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing config question</h1>
+  <h1>Editing config question</h1>
 
   <%= render "form", config_question: @config_question %>
 

--- a/app/views/config_questions/index.html.erb
+++ b/app/views/config_questions/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Config questions</h1>
+    <h1>Config questions</h1>
     <%= link_to 'New config question', new_config_question_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/config_questions/new.html.erb
+++ b/app/views/config_questions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New config question</h1>
+  <h1>New config question</h1>
 
   <%= render "form", config_question: @config_question %>
 

--- a/app/views/program_managers/edit.html.erb
+++ b/app/views/program_managers/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing program manager</h1>
+  <h1>Editing program manager</h1>
 
   <%= render "form", program_manager: @program_manager %>
 

--- a/app/views/program_managers/index.html.erb
+++ b/app/views/program_managers/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Program managers</h1>
+    <h1>Program managers</h1>
     <%= link_to 'New program manager', new_program_manager_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/program_managers/new.html.erb
+++ b/app/views/program_managers/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New program manager</h1>
+  <h1>New program manager</h1>
 
   <%= render "form", program_manager: @program_manager %>
 

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing program</h1>
+  <h1>Editing program</h1>
 
   <%= render "form", program: @program %>
 

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Programs</h1>
+    <h1>Programs</h1>
     <%= link_to 'New program', new_program_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/programs/new.html.erb
+++ b/app/views/programs/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New program</h1>
+  <h1 class="">New program</h1>
 
   <%= render "form", program: @program %>
 

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing reservation</h1>
+  <h1>Editing reservation</h1>
 
   <%= render "form", reservation: @reservation %>
 

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Reservations</h1>
+    <h1>Reservations</h1>
     <%= link_to 'New reservation', new_reservation_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New reservation</h1>
+  <h1>New reservation</h1>
 
   <%= render "form", reservation: @reservation %>
 

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing site</h1>
+  <h1>Editing site</h1>
 
   <%= render "form", site: @site %>
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Sites</h1>
+    <h1>Sites</h1>
     <%= link_to 'New site', new_site_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New site</h1>
+  <h1>New site</h1>
 
   <%= render "form", site: @site %>
 

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing student</h1>
+  <h1>Editing student</h1>
 
   <%= render "form", student: @student %>
 

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Students</h1>
+    <h1>Students</h1>
     <%= link_to 'New student', new_student_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New student</h1>
+  <h1>New student</h1>
 
   <%= render "form", student: @student %>
 

--- a/app/views/vehicle_reports/edit.html.erb
+++ b/app/views/vehicle_reports/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing vehicle report</h1>
+  <h1>Editing vehicle report</h1>
 
   <%= render "form", vehicle_report: @vehicle_report %>
 

--- a/app/views/vehicle_reports/index.html.erb
+++ b/app/views/vehicle_reports/index.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Vehicle reports</h1>
+    <h1>Vehicle reports</h1>
     <%= link_to 'New vehicle report', new_vehicle_report_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/vehicle_reports/new.html.erb
+++ b/app/views/vehicle_reports/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New vehicle report</h1>
+  <h1>New vehicle report</h1>
 
   <%= render "form", vehicle_report: @vehicle_report %>
 

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -13,9 +13,9 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
-        oswald: ['Oswald'],
-        montserrat: ['Montserrat'],
+        sans: ['Inter var'],
+        oswald: ['Oswald', 'sans-serif'],
+        montserrat: ['Montserrat', 'sans-serif'],
       },
     },
     colors: {
@@ -72,7 +72,8 @@ module.exports = {
         750: '#9D691B',
         800: '#975a16',
         900: '#744210',
-        umyellow: '#ffcb05'
+        umyellow: '#ffcb05',
+        ummaze: '#FFCF01'
       },
       green: {
         100: '#f0fff4',


### PR DESCRIPTION
To use styles and fonts that Maria designed in the Figma dashboard (see the [ticket](https://umlsait.atlassian.net/jira/software/projects/LRA/boards/104?selectedIssue=LRA-521) for the link) we need to add Google fonts (Oswald and Montserrat) to the application.
Also, I added dartsass-rails gem to process an scss stylesheet (btw, sass-rails is deprecated).
I added some style classes to the application.tailwind.css and application.scss files (Maria saw them and approved them).
And, of course, we can edit them later.
In views files I replaced `<h1 class="font-bold text-4xl">` with `<h1>` to use the h1 class from the stylesheet.