### PR TITLE
Hide programs in header

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,5 +1,6 @@
 class ProgramsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :auth_user
+
   before_action :set_program, only: %i[ show edit update destroy duplicate remove_car remove_site remove_program_manager add_config_questions remove_config_question]
   before_action :set_terms
 
@@ -123,6 +124,12 @@ class ProgramsController < ApplicationController
 
     def set_terms
       @terms = Term.all
+    end
+
+    def auth_user
+      unless user_signed_in?
+        redirect_to root_path, notice: 'You must sign in first!'
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,9 +18,11 @@
           <div class="header_link">
             <%= link_to "Home", static_pages_home_path, class: "#{class_names(active: current_page?(static_pages_home_path))}" %>
           </div>
-          <div class="header_link">
-            <%= link_to "Programs", programs_path, class: "#{class_names(active: current_page?(programs_path))}" %>
-          </div>
+          <% if user_signed_in? %>
+            <div class="header_link">
+              <%= link_to "Programs", programs_path, class: "#{class_names(active: current_page?(programs_path))}" %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="hidden sm:ml-6 sm:flex sm:items-center">


### PR DESCRIPTION
Hide the Programs link until the user signs in.
Tell the user to sign in before going to program's direct URLs.

