### PR TITLE
use different group as a SuperAdmin group

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -49,7 +49,7 @@ def set_user
     session[:user_email] = @user.email
 
     membership = []
-    access_groups = Unit.pluck(:ldap_group) + ['lsa-rideshare-admins']
+    access_groups = Unit.pluck(:ldap_group) + ['lsa-was-rails-devs']
     access_groups.each do |group|
       if  LdapLookup.is_member_of_group?(@user.uniqname, group)
         membership.append(group)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
   end
 
   def is_super_admin?(user)
-    user.membership.include?('lsa-rideshare-admins')
+    user.membership.include?('lsa-was-rails-devs')
   end
   
   def render_flash_stream

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -42,7 +42,7 @@ class ApplicationPolicy
   end
 
   def user_admin?
-    user.membership && user.membership.include?('lsa-rideshare-admins')
+    user.membership && user.membership.include?('lsa-was-rails-devs')
   end
 
   def user_in_access_group?


### PR DESCRIPTION
Replaced 'lsa-rideshare-admins' group with 'lsa-was-rails-devs' group. 
Members of that group have SuperAdmin assess rights to the application.