### PR TITLE
Add sites to a duplicated program

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -19,7 +19,7 @@ class ProgramsController < ApplicationController
   end
 
   def duplicate
-    @copy_from_id = @program.id
+    @duplicate_program_id = @program.id
     @program = @program.dup
     render :new
   end
@@ -47,7 +47,7 @@ class ProgramsController < ApplicationController
 
   # POST /programs or /programs.json
   def create
-    @program = Program.new(program_params.except(:instructor_attributes, :copy_from_id))
+    @program = Program.new(program_params.except(:instructor_attributes, :duplicate_program_id))
     uniqname = program_params[:instructor_attributes][:uniqname]
     if ProgramManager.find_by(uniqname: uniqname).present?
       instructor = ProgramManager.find_by(uniqname: uniqname)
@@ -58,9 +58,9 @@ class ProgramsController < ApplicationController
     authorize @program
     respond_to do |format|
       if @program.save
-        if params[:program][:copy_from_id].present?
+        if params[:program][:duplicate_program_id].present?
           # carry forward sites when program is carried forward
-          @program.sites << Program.find(params[:program][:copy_from_id]).sites
+          @program.sites << Program.find(params[:program][:duplicate_program_id]).sites
         end
         format.html { redirect_to program_url(@program), notice: "Program was successfully created." }
         format.json { render :show, status: :created, location: @program }
@@ -134,6 +134,6 @@ class ProgramsController < ApplicationController
       params.require(:program).permit(:active, :title, :term_start, :term_end, :term_id, :subject, :catalog_number, :class_section, 
                                      :number_of_students, :number_of_students_using_ride_share, :pictures_required_start, :pictures_required_end, 
                                      :non_uofm_passengers, :instructor_id, :mvr_link, :canvas_link, :canvas_course_id, :unit_id, :add_managers, 
-                                     :not_course, :updated_by, instructor_attributes: [:uniqname])
+                                     :not_course, :updated_by, :duplicate_program_id, instructor_attributes: [:uniqname])
     end
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -50,12 +50,10 @@ class Program < ApplicationRecord
 
   def dup
     super.tap do |new_program|
-
       new_program.term_id = nil
       new_program.number_of_students = ""
       new_program.number_of_students_using_ride_share = ""
       new_program.updated_by = ""
-
     end
   end
 

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -115,8 +115,8 @@
   </div>
 
   <%= form.hidden_field :updated_by, value: current_user.id %>
-  <% if @copy_from_id.present? %> 
-    <%= form.hidden_field :copy_from_id, value: @copy_from_id %>
+  <% if @duplicate_program_id.present? %> 
+    <%= form.hidden_field :duplicate_program_id, value: @duplicate_program_id %>
   <% end %>
 
   <div class="inline">

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -115,6 +115,9 @@
   </div>
 
   <%= form.hidden_field :updated_by, value: current_user.id %>
+  <% if @copy_from_id.present? %> 
+    <%= form.hidden_field :copy_from_id, value: @copy_from_id %>
+  <% end %>
 
   <div class="inline">
     <%= form.submit class: "primary_button" %>


### PR DESCRIPTION
When programs are duplicated the sites associated with those programs should also carry forward.
For that purpose, the id of the original program (@copy_from_id) is passed to the create method (from the duplicate method). After a new program is created sites from the original program are added to the new one: 
@program.sites << Program.find(params[:program][:copy_from_id]).sites