### PR TITLE
rename unit attribute to unit_ids

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,9 +22,9 @@ class ApplicationController < ActionController::Base
     if user_signed_in?
       current_user.membership = session[:user_memberships]
       if is_super_admin?(current_user)
-        current_user.unit = Unit.all.pluck(:id)
+        current_user.unit_ids = Unit.all.pluck(:id)
       else
-        current_user.unit = Unit.where(ldap_group: session[:user_memberships]).pluck(:id)
+        current_user.unit_ids = Unit.where(ldap_group: session[:user_memberships]).pluck(:id)
       end
     else
       new_user_session_path

--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -9,7 +9,7 @@ class CarsController < ApplicationController
     if params[:unit_id].present?
       @cars = Car.where(unit_id: params[:unit_id]).order(:car_number)
     else
-      @cars = Car.where(unit_id: current_user.unit).order(:car_number)
+      @cars = Car.where(unit_id: current_user.unit_ids).order(:car_number)
     end
     authorize @cars
     
@@ -77,7 +77,7 @@ class CarsController < ApplicationController
     end
 
     def set_units
-      @units = Unit.where(id: current_user.unit).order(:name)
+      @units = Unit.where(id: current_user.unit_ids).order(:name)
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/faculty_surveys_controller.rb
+++ b/app/controllers/faculty_surveys_controller.rb
@@ -77,9 +77,9 @@ class FacultySurveysController < ApplicationController
 
     def set_units
       @units = []
-      current_user.unit.each do |unit|
-        if unit_use_faculty_survey(unit)
-          @units << Unit.find(unit)
+      current_user.unit_ids.each do |unit_id|
+        if unit_use_faculty_survey(unit_id)
+          @units << Unit.find(unit_id)
         end
       end
     end

--- a/app/controllers/programs/sites_controller.rb
+++ b/app/controllers/programs/sites_controller.rb
@@ -66,7 +66,7 @@ class Programs::SitesController < SitesController
     end
 
     def set_units
-      @units = Unit.where(id: current_user.unit).order(:name)
+      @units = Unit.where(id: current_user.unit_ids).order(:name)
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -13,7 +13,7 @@ class ProgramsController < ApplicationController
     if params[:unit_id].present?
       @programs = Program.where(unit_id: params[:unit_id])
     else
-      @programs = Program.where(unit_id: current_user.unit)
+      @programs = Program.where(unit_id: current_user.unit_ids)
     end
     @programs = @programs.data(params[:term_id])
     authorize @programs
@@ -128,7 +128,7 @@ class ProgramsController < ApplicationController
     end
 
     def set_units
-      @units = Unit.where(id: current_user.unit).order(:name)
+      @units = Unit.where(id: current_user.unit_ids).order(:name)
     end
 
     def set_terms

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -7,7 +7,7 @@ class SitesController < ApplicationController
     if params[:unit_id].present?
       @sites = Site.where(unit_id: params[:unit_id])
     else
-      @sites = Site.where(unit_id: current_user.unit)
+      @sites = Site.where(unit_id: current_user.unit_ids)
     end
     authorize @sites
   end
@@ -38,7 +38,7 @@ class SitesController < ApplicationController
     end
 
     def set_units
-      @units = Unit.where(id: current_user.unit).order(:name)
+      @units = Unit.where(id: current_user.unit_ids).order(:name)
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/unit_preferences_controller.rb
+++ b/app/controllers/unit_preferences_controller.rb
@@ -9,12 +9,12 @@ class UnitPreferencesController < ApplicationController
   end
 
   def unit_prefs
-    @unit_prefs = UnitPreference.where(unit_id: current_user.unit).order(:description)
+    @unit_prefs = UnitPreference.where(unit_id: current_user.unit_ids).order(:description)
     authorize @unit_prefs
   end
 
   def save_unit_prefs
-    @unit_prefs = UnitPreference.where(unit_id: current_user.unit)
+    @unit_prefs = UnitPreference.where(unit_id: current_user.unit_ids)
     authorize @unit_prefs
     @unit_prefs.update(value: false)
     if params[:unit_prefs].present?
@@ -69,7 +69,7 @@ class UnitPreferencesController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
 
     def set_units
-      @units = Unit.where(id: current_user.unit)
+      @units = Unit.where(id: current_user.unit_ids)
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,12 +42,12 @@ module ApplicationHelper
     if is_super_admin?(user)
       "SuperAdmin"
     else
-      Unit.where(id: current_user.unit).pluck(:name).join(' ')
+      Unit.where(id: current_user.unit_ids).pluck(:name).join(' ')
     end
   end
 
-  def unit_use_faculty_survey(unit)
-    UnitPreference.where(unit_id: unit, name: "faculty_survey").present? && UnitPreference.where(unit_id: unit, name: "faculty_survey").pluck(:value).include?(true)
+  def unit_use_faculty_survey(unit_id)
+    UnitPreference.where(unit_id: unit_id, name: "faculty_survey").present? && UnitPreference.where(unit_id: unit_id, name: "faculty_survey").pluck(:value).include?(true)
   end
 
   def is_super_admin?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:saml]
 
-  attr_accessor :membership, :unit
+  attr_accessor :membership, :unit_ids
 
   def display_name_email
     "#{display_name} - #{email}"

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -37,8 +37,8 @@ class ApplicationPolicy
   end
 
   def unit_admin?
-    units = Unit.all.pluck(:id)
-    user.unit && (user.unit & units).any?
+    units_all_ids = Unit.all.pluck(:id)
+    user.unit_ids && (user.unit_ids & units_all_ids).any?
   end
 
   def user_admin?

--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div>
-    <% if current_user.unit.count > 1 %>
+    <% if current_user.unit_ids.count > 1 %>
       <%= form_with url: cars_path, method: :get, class: "", data: { autosubmit_target: "form", turbo_frame: "turbo-cars" } do |form| %>
 
         <div class="mb-4">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,7 @@
                 <%= link_to "Unit Preferences", unit_preferences_path, class: "#{class_names(active: current_page?(unit_preferences_path))}" %>
               </div>
             <% end %>
-            <% if unit_use_faculty_survey(current_user.unit) %>
+            <% if unit_use_faculty_survey(current_user.unit_ids) %>
               <div class="header_link">
                 <%= link_to "Faculty Surveys", faculty_surveys_path, class: "#{class_names(active: current_page?(faculty_surveys_path))}" %>
               </div>

--- a/app/views/layouts/_mobile_menu_dropdown.html.erb
+++ b/app/views/layouts/_mobile_menu_dropdown.html.erb
@@ -14,7 +14,7 @@
         <div>
           <% if user_signed_in? %>
             <div class="leading-tight text-sm font-medium text-white">
-              <%= Unit.where(id: current_user.unit).pluck(:name) %>
+              <%= Unit.where(id: current_user.unit_ids).pluck(:name) %>
             </div>
             <div class="leading-tight text-md font-medium text-white">
               <%= current_user.email %>

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         </div>
 
-        <% if current_user.unit.count > 1 %>
+        <% if current_user.unit_ids.count > 1 %>
           <div class="">
             <label for="unit_id" class="fancy_label">Select a Unit</label>
             <%= select_tag "unit_id", options_from_collection_for_select(@units, :id, :name, selected: params[:unit_id]), include_blank: "All Units", class: "filter_select w-48",

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="mb-4">Sites</h1>
     <p class="body-text">To Add a new Site, go to <%= link_to 'Programs', programs_path, class: "link_to" %> and add the site there</p>
   <div>
-    <% if current_user.unit.count > 1 %>
+    <% if current_user.unit_ids.count > 1 %>
       <%= form_with url: sites_path, method: :get, class: "", data: { autosubmit_target: "form", turbo_frame: "sites" } do |form| %>
         <div class="mb-4">
           <label for="unit_id" class="fancy_label">Select a Unit</label>


### PR DESCRIPTION
The User had a virtual :unit attribute, which is created for a session and is an array of current_user's units.
I called that attribute the :unit, but actually, it's an array of units' ids.
This is why it makes sense to call it units_ids - thank you, Ananta, for your suggestion to rename it.