### PR TITLE
Lra 579 lsa ride share sites should belong to units

### DIFF
--- a/app/controllers/programs/sites_controller.rb
+++ b/app/controllers/programs/sites_controller.rb
@@ -37,8 +37,6 @@ class Programs::SitesController < SitesController
         flash.now[:notice] = "The site was added."
       end
     end
-    @sites = @site_program.sites
-    @all_sites = Site.all - @sites
   end
 
   # DELETE /sites/1 or /sites/1.json
@@ -47,16 +45,12 @@ class Programs::SitesController < SitesController
       flash.now[:notice] = "The site was removed from the program."
     end
     @site = Site.new
-    @sites = @site_program.sites
-    @all_sites = Site.all - @sites
   end
 
   private
 
     def set_site_program
       @site_program = Program.find(params[:program_id])
-      @sites = @site_program.sites
-      @all_sites = Site.all - @sites
     end
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,6 +50,11 @@ module ApplicationHelper
     UnitPreference.where(unit_id: unit_id, name: "faculty_survey").present? && UnitPreference.where(unit_id: unit_id, name: "faculty_survey").pluck(:value).include?(true)
   end
 
+  def choose_sites_for_program(program)
+    sites = program.sites
+    Site.where(unit_id: program.unit) - sites
+  end
+
   def is_super_admin?(user)
     user.membership.include?('lsa-was-rails-devs')
   end

--- a/app/views/programs/sites/_form.html.erb
+++ b/app/views/programs/sites/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div class="my-2">
       <label for="site_id" class="fancy_label">Select a Site</label>
-      <%= select_tag "site_id", options_from_collection_for_select(@all_sites, :id, :title), include_blank: "Select", class: "input_text_field",
+      <%= select_tag "site_id", options_from_collection_for_select(choose_sites_for_program(@site_program), :id, :title), include_blank: "Select", class: "input_text_field",
         :"data-action" => "change->autosubmit#search" %>
     </div>
 

--- a/app/views/programs/sites/_site_list.html.erb
+++ b/app/views/programs/sites/_site_list.html.erb
@@ -10,7 +10,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @sites.each do |site| %>
+        <% @site_program.sites.each do |site| %>
           <tr class="mi_tbody_tr">
             <td class="mi_tbody_td">
               <%= link_to site.title, site_path(site), class: "link_to" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,3 +31,5 @@ terms = Term.create!([
 
 Unit.create!(name: "Psychology", ldap_group: "psych.transportation")
 Unit.create!(name: "Residential College", ldap_group: "rc-rideshare-admins-test")
+Unit.create!(name: "Test Unit", ldap_group: "test-unit-rideshare-admins")
+


### PR DESCRIPTION
Fix the problem when the list of sites for a program to add from consisted of sites for all units.
Now the list has only sites for the unit that the program in question belongs to.