### PR TITLE
replace program title in sites index page with more information

### DIFF
--- a/app/views/sites/_listing.html.erb
+++ b/app/views/sites/_listing.html.erb
@@ -19,7 +19,7 @@
             </td>
             <td class="mi_tbody_td">
               <% site.programs.each do |program| %>
-                <%= program.title %>
+                <%= program.display_name_with_title %>
                 <br>
               <% end %>
             </td>


### PR DESCRIPTION
Since many programs have the same title it was not clear which program was referenced in the list of programs on the Sites index page.
I added the information about the subject, catalog number, and term to the title of the program.