### PR TITLE
LRA-519-lsa-ride-share-add-notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,12 +74,7 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console"
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
   gem 'annotate', '~> 3.2'
+  gem 'letter_opener_web', '~> 2.0'
+  gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,8 +167,17 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jwt (2.7.0)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     ldap_lookup (0.1.7)
       net-ldap (~> 0.17.0)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -366,6 +375,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   ldap_lookup (~> 0.1.6)
+  letter_opener_web (~> 2.0)
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1)
   pg (~> 1.1)

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,13 @@
+class AdminMailer < ApplicationMailer
+  def test
+    # if Rails env is development, use current_user, otherwise use a dummy user
+    if Rails.env.development?
+      @user = User.first
+    else
+      @user = current_user
+    end
+
+    @url = 'https://rideshare.lsa.umich.edu/'
+    mail(to: @user.email, subject: 'Testing the Admin Mailer')
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  prepend_view_path "app/views/mailers"
+  default from: "lsa-rideshare-admins@umich.edu"
   layout "mailer"
 end

--- a/app/views/mailers/admin_mailer/test.html.erb
+++ b/app/views/mailers/admin_mailer/test.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Testing LSA Ride Share, <%= @user.display_name %></h1>
+    <p>
+      You have successfully signed up to example.com,
+      your username is: <%= @user.email %>.<br>
+    </p>
+    <p>
+      To login to the site, just follow this link: <%= @url %>.
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/app/views/mailers/admin_mailer/test.text.erb
+++ b/app/views/mailers/admin_mailer/test.text.erb
@@ -1,0 +1,9 @@
+Testing LSA Ride Share, <%= @user.display_name %>
+===============================================
+
+You have successfully signed up to example.com,
+your username is: <%= @user.email %>.
+
+To login to the site, just follow this link: <%= @url %>.
+
+Thanks for joining and have a great day!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,10 +36,32 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Devise setting - Ensure you have defined default url options
+  # host = 'http://localhost:3000'
+  host = 'https://rideshare-staging.lsa.umich.edu/'
+  config.action_mailer.default_url_options = { host: host }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+
+  #letter_opener settings
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+
+=begin
+  # From https://makandracards.com/makandra/52335-actionmailer-how-to-send-a-test-mail-directly-from-the-console
+  # To test the mailers in the Rails console, you can use the following command:
+  mailer = ActionMailer::Base.new
+
+  # check settings:
+  mailer.delivery_method # -> :smtp
+  mailer.smtp_settings # -> { address: "localhost", port: 25, domain: "localhost.localdomain", user_name: nil, password: nil, authentication: nil, enable_starttls_auto: true }
+
+  # send mail:
+  mailer.mail(from: 'sender@example.com', to: 'recipient@example.com', subject: 'test', body: "Hello, you've got mail!").deliver
+=end
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,8 +64,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
@@ -74,6 +76,19 @@ Rails.application.configure do
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'https://rideshare.lsa.umich.edu/'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => 'apikey',
+    :password       => ENV['SENDGRID_API_KEY'],
+    :domain         => 'umich.edu',
+    :enable_starttls_auto => true
+  }
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,6 +63,19 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "art_survey_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'https://rideshare-staging.lsa.umich.edu/'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => 'apikey',
+    :password       => ENV['SENDGRID_API_KEY'],
+    :domain         => 'umich.edu',
+    :enable_starttls_auto => true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+
+  root to: "static_pages#home"
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   resources :faculty_surveys do
     resources :config_questions, module: :faculty_surveys
   end
@@ -62,11 +67,6 @@ Rails.application.routes.draw do
   resources :notes
   
   get 'static_pages/home'
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
-  root to: "static_pages#home"
 
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks", sessions: "users/sessions"} do
     delete 'sign_out', :to => 'users/sessions#destroy', :as => :destroy_user_session

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AdminMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/admin_preview.rb
+++ b/spec/mailers/previews/admin_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/admin
+class AdminPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
This PR sets up the intitial mailer configuration using the [SendGrid](https://docs.sendgrid.com/) service from Twilio.

I added an Admin mailer and test methids to allow for running the mailer locally using letteropener. To view results in letteropener naivagte to (http://localhost:3000/letter_opener/)

The Staging and Production configurations run through SendGrid's SMTP service. I need to have the config run on the Staging server to be able to confirm the configurations and adjust them.

To send a test email from a Rails console:
#After logging into the hosting server open the rails console and enter 

  # To test the mailers in the Rails console, you can use the following command:
mailer = ActionMailer::Base.new

  # check settings:
mailer.delivery_method # -> :smtp ( SMTP based service ie. staging or production show :smtp, development environment will show :letter_opener_web)
mailer.smtp_settings # -> { address: "localhost", port: 25, domain: "localhost.localdomain", user_name: nil, password: nil, authentication: nil, enable_starttls_auto: true } (only works on SMTP based service ie. staging or production)

  # send mail:
mailer.mail(from: 'sender@example.com', to: '<UNIQNAME>@umich.edu', subject: 'test', body: "Hello, you've got mail!").deliver


# You can also test the actual flow of email in the application at the Rails console by entering:
AdminMailer.test.deliver