### PR TITLE
Lra 577 lsa ride share faculty survey: give faculty access to add sites to created programs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def pundit_user
-    { user: current_user, params: params[:program_id] }
+    { user: current_user, params: params.except("controller",  "action") }
   end
 
   def auth_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,10 @@ class ApplicationController < ActionController::Base
     redirect_to(root_path)
   end
 
+  def pundit_user
+    { user: current_user, params: params[:program_id] }
+  end
+
   def auth_user
     unless user_signed_in?
       redirect_to root_path, notice: 'You must sign in first!'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def pundit_user
-    { user: current_user, params: params.except("controller",  "action") }
+    { user: current_user, params: params }
   end
 
   def auth_user

--- a/app/controllers/faculty_surveys/config_questions_controller.rb
+++ b/app/controllers/faculty_surveys/config_questions_controller.rb
@@ -57,7 +57,7 @@ class FacultySurveys::ConfigQuestionsController < ApplicationController
       return
     end
     unless @faculty_survey.program_id.present?
-      program_id = new_survey.create_program_from_survey
+      program_id = new_survey.create_program_from_survey(current_user)
       if program_id
         @faculty_survey.update(program_id: program_id)
       else

--- a/app/controllers/programs/sites_controller.rb
+++ b/app/controllers/programs/sites_controller.rb
@@ -6,7 +6,7 @@ class Programs::SitesController < SitesController
   # GET /sites/new
   def new
     @site = Site.new
-    authorize @site
+    authorize([@site_program, @site]) 
   end
 
   # GET /sites/1/edit
@@ -16,21 +16,21 @@ class Programs::SitesController < SitesController
 
   def edit_program_sites
     @site = Site.new
-    authorize @site
+    authorize([@site_program, @site]) 
   end
 
   # POST /sites or /sites.json
   def create
     if params[:site_id].present?
       @site = Site.find(params[:site_id])
-      authorize @site
+      authorize([@site_program, @site]) 
       if @site_program.sites << @site
         @site = Site.new
         flash.now[:notice] = "The site was added."
       end
     else
      @site = Site.new(site_params)
-     authorize @site
+     authorize([@site_program, @site]) 
       if @site.save
         @site_program.sites << @site
         @site = Site.new
@@ -56,7 +56,7 @@ class Programs::SitesController < SitesController
     # Use callbacks to share common setup or constraints between actions.
     def set_site
       @site = Site.find(params[:id])
-      authorize @site
+      authorize([@site_program, @site]) 
     end
 
     def set_units

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -16,6 +16,11 @@ class ProgramsController < ApplicationController
       @programs = Program.where(unit_id: current_user.unit_ids)
     end
     @programs = @programs.data(params[:term_id])
+    if is_manager?(current_user)
+      @programs = Program.all.data(params[:term_id])
+      programs = Manager.find_by(uniqname: current_user.uniqname).programs
+      @programs = @programs.where(id: programs.map(&:id))
+    end
     authorize @programs
 
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,7 +60,11 @@ module ApplicationHelper
 
   def rich_text_no_tags_value(field)
     strip_tags(field.body.to_s).strip
-  end 
+  end
+
+  def has_answers?(faculty_survey)
+    Survey.new(faculty_survey).has_answers?
+  end
   
   def choose_managers_for_program(program)
     managers = Manager.all - program.managers

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,6 +90,10 @@ module ApplicationHelper
     user.membership.present?
   end
 
+  def is_manager?(user)
+    Program.all.map { |p| p.all_managers.include?(user.uniqname) }.any?
+  end
+  
   def render_flash_stream
     turbo_stream.update "flash", partial: "layouts/notification"
   end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -94,4 +94,8 @@ class Program < ApplicationRecord
     end
   end
 
+  def all_managers
+    self.managers.map(&:uniqname) << self.instructor.uniqname
+  end
+
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -34,6 +34,10 @@ class Survey
     return survey
   end
 
+  def has_answers?
+    rich_text_no_tags_value(@survey_to_update[0].answer).present?
+  end
+
   def update_answers(params)
     result = { 'success' => true, 'note' => '' }
     course = false

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -78,7 +78,7 @@ class Survey
             result['success'] = false
             result['note'] += "Catalog number is required. "
           when '5'
-            result['success'] = falses
+            result['success'] = false
             result['note'] += "Section is required. "
           end
         end
@@ -92,8 +92,13 @@ class Survey
     return result
   end
 
-  def create_program_from_survey
+  def create_program_from_survey(current_user)
     not_course = false
+    title = ''
+    subject = ''
+    catalog_number = ''
+    class_section = ''
+    number_of_students_using_ride_share = 0
     @survey_to_update.each do |s|
       if rich_text_value(s.question).include?("title")
         title = rich_text_no_tags_value(s.answer)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationPolicy
-  attr_reader :user, :record
+  attr_reader :user, :params, :record
 
-  def initialize(user, record)
-    @user = user
+  def initialize(context, record)
+    @user = context[:user]
+    @program_id = context[:params]
     @record = record
   end
 
@@ -38,11 +39,11 @@ class ApplicationPolicy
 
   def unit_admin?
     units_all_ids = Unit.all.pluck(:id)
-    user.unit_ids && (user.unit_ids & units_all_ids).any?
+    @user.unit_ids && (@user.unit_ids & units_all_ids).any?
   end
 
   def user_admin?
-    user.membership && user.membership.include?('lsa-was-rails-devs')
+    @user.membership && @user.membership.include?('lsa-was-rails-devs')
   end
 
   def user_in_access_group?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -5,7 +5,7 @@ class ApplicationPolicy
 
   def initialize(context, record)
     @user = context[:user]
-    @program_id = context[:params]
+    @params = context[:params]
     @record = record
   end
 

--- a/app/policies/car_policy.rb
+++ b/app/policies/car_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class CarPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/policies/config_question_policy.rb
+++ b/app/policies/config_question_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ConfigQuestionPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     @user.uniqname == FacultySurvey.find(@record[0].faculty_survey_id).uniqname || @user.unit_ids.include?(FacultySurvey.find(@record[0].faculty_survey_id).unit_id)

--- a/app/policies/contact_policy.rb
+++ b/app/policies/contact_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ContactPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/policies/faculty_survey_policy.rb
+++ b/app/policies/faculty_survey_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class FacultySurveyPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/policies/manager_policy.rb
+++ b/app/policies/manager_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ManagerPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def create?
     user_in_access_group?

--- a/app/policies/program/site_policy.rb
+++ b/app/policies/program/site_policy.rb
@@ -27,7 +27,7 @@ class Program::SitePolicy < ApplicationPolicy
   end
 
   def is_program_instructor?
-    Program.find(@program_id).instructor == Manager.find_by(uniqname: @user.uniqname)
+    Program.find(@params[:program_id]).instructor == Manager.find_by(uniqname: @user.uniqname)
   end
 
 end

--- a/app/policies/program/site_policy.rb
+++ b/app/policies/program/site_policy.rb
@@ -19,7 +19,7 @@ class Program::SitePolicy < ApplicationPolicy
   end
 
   def edit_program_sites?
-    is_program_instructor?
+    user_in_access_group? || is_program_instructor?
   end
 
   def remove_site_from_program?

--- a/app/policies/program/site_policy.rb
+++ b/app/policies/program/site_policy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Program::SitePolicy < ApplicationPolicy
+
+  def create?
+    user_in_access_group? || is_program_instructor?
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user_in_access_group? || is_program_instructor?
+  end
+
+  def edit?
+    update?
+  end
+
+  def edit_program_sites?
+    is_program_instructor?
+  end
+
+  def remove_site_from_program?
+    user_in_access_group? || is_program_instructor?
+  end
+
+  def is_program_instructor?
+    Program.find(@program_id).instructor == Manager.find_by(uniqname: @user.uniqname)
+  end
+
+end

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -19,7 +19,7 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_access_group? || is_program_manager?
+    user_in_access_group? || is_instructor?
   end
 
   def edit?
@@ -44,6 +44,10 @@ class ProgramPolicy < ApplicationPolicy
 
   def is_program_manager?
     @record.all_managers.include?(@user.uniqname)
+  end
+
+  def is_instructor?
+    @record.instructor.uniqname == @user.uniqname
   end
 
 end

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ProgramPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group? || is_manager?

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -9,11 +9,11 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def index?
-    user_in_access_group?
+    user_in_access_group? || is_manager?
   end
 
   def show?
-    user_in_access_group?
+    user_in_access_group? || is_program_manager?
   end
 
   def create?
@@ -25,7 +25,7 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_access_group?
+    user_in_access_group? || is_program_manager?
   end
 
   def edit?
@@ -42,6 +42,14 @@ class ProgramPolicy < ApplicationPolicy
 
   def destroy?
     false
+  end
+
+  def is_manager?
+    Program.all.map { |p| p.all_managers.include?(@user.uniqname) }.any?
+  end
+
+  def is_program_manager?
+    @record.all_managers.include?(@user.uniqname)
   end
 
 end

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ReservationPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def show?
     user_in_access_group?

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -26,14 +26,6 @@ class SitePolicy < ApplicationPolicy
     update?
   end
 
-  # def edit_program_sites?
-  #   update?
-  # end
-
-  # def remove_site_from_program?
-  #   user_in_access_group? || is_instructor?
-  # end
-
   def is_instructor?
     manager = Manager.find_by(uniqname: @user.uniqname)
     Program.where(instructor_id: manager).present?

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -13,11 +13,11 @@ class SitePolicy < ApplicationPolicy
   end
 
   def show?
-    user_in_access_group?
+    user_in_access_group? || is_instructor?
   end
 
   def create?
-    user_in_access_group?
+    user_in_access_group? || is_instructor?
   end
 
   def new?
@@ -25,7 +25,7 @@ class SitePolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_access_group? 
+    user_in_access_group? || is_instructor?
   end
 
   def edit?
@@ -37,7 +37,12 @@ class SitePolicy < ApplicationPolicy
   end
 
   def remove_site_from_program?
-    user_in_access_group?
+    user_in_access_group? || is_instructor?
+  end
+
+  def is_instructor?
+    manager = Manager.find_by(uniqname: @user.uniqname)
+    Program.where(instructor_id: manager).present?
   end
 
 end

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class SitePolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?
@@ -32,13 +26,13 @@ class SitePolicy < ApplicationPolicy
     update?
   end
 
-  def edit_program_sites?
-    update?
-  end
+  # def edit_program_sites?
+  #   update?
+  # end
 
-  def remove_site_from_program?
-    user_in_access_group? || is_instructor?
-  end
+  # def remove_site_from_program?
+  #   user_in_access_group? || is_instructor?
+  # end
 
   def is_instructor?
     manager = Manager.find_by(uniqname: @user.uniqname)

--- a/app/policies/student_policy.rb
+++ b/app/policies/student_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class StudentPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/policies/survey_policy.rb
+++ b/app/policies/survey_policy.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 class SurveyPolicy < ApplicationPolicy
-  attr_reader :user, :survey
-
-  def initialize(user, survey)
-    @user = user
-    @survey = survey
-  end
 
   def survey?
-    @user.uniqname == @survey.uniqname
+    @user.uniqname == @record.uniqname
   end
 
   def save_survey?
-    @user.uniqname == @survey.uniqname
+    @user.uniqname == @record.uniqname
   end
 
 end

--- a/app/policies/term_policy.rb
+++ b/app/policies/term_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class TermPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/policies/unit_policy.rb
+++ b/app/policies/unit_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class UnitPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_admin?

--- a/app/policies/unit_preference_policy.rb
+++ b/app/policies/unit_preference_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class UnitPreferencePolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_admin?

--- a/app/policies/vehicle_report_policy.rb
+++ b/app/policies/vehicle_report_policy.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class VehicleReportPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
 
   def index?
     user_in_access_group?

--- a/app/views/faculty_surveys/_survey_list.html.erb
+++ b/app/views/faculty_surveys/_survey_list.html.erb
@@ -14,7 +14,11 @@
         <% @surveys_list.each do |survey| %>
           <tr class="mi_tbody_tr">
             <td class="mi_tbody_td">
-              <%= link_to 'Questions', survey_path(survey), class: "link_to" %>
+            <% if has_answers?(survey) %>
+              <%= link_to 'Edit the Survey', faculty_survey_config_questions_path(survey), class: "link_to" %>
+            <% else %>
+              <%= link_to 'Answer the Survey', survey_path(survey), class: "link_to" %>
+            <% end %>
             </td>
             <td class="mi_tbody_td">
               <%= survey.uniqname %>

--- a/app/views/faculty_surveys/config_questions/index.html.erb
+++ b/app/views/faculty_surveys/config_questions/index.html.erb
@@ -10,12 +10,12 @@
   </div>
   <div class="body-text mb-2">
     <% if @faculty_survey.program_id.present? %>
-      <div class="inline">
-        Program
-        <%= link_to Program.find_by(id: @faculty_survey.program_id).display_name_with_title, program_path(Program.find_by(id: @faculty_survey.program_id)), class: "link_to" %>
-        was created for this survey. Follow the link to edit the program
-      </div>
-      <div class="inline">
+      <div class="flex justify-between items-center mb-4">
+        <p>
+          Program
+          <%= link_to Program.find_by(id: @faculty_survey.program_id).display_name_with_title, program_path(Program.find_by(id: @faculty_survey.program_id)), class: "link_to" %>
+          was created for this survey. Follow the link to edit the program
+        </p>
         <%= link_to 'Add Sites to Program', edit_program_sites_path(@faculty_survey.program_id), class: "secondary_blue_button" unless is_admin?(current_user) %> 
       </div>
     <% else %>

--- a/app/views/faculty_surveys/config_questions/index.html.erb
+++ b/app/views/faculty_surveys/config_questions/index.html.erb
@@ -16,7 +16,7 @@
         was created for this survey. Follow the link to edit the program
       </div>
       <div class="inline">
-        <%= link_to 'Add Sites to Program', faculty_survey_config_questions_path(@faculty_survey), class: "secondary_blue_button" unless is_admin?(current_user) %> 
+        <%= link_to 'Add Sites to Program', edit_program_sites_path(@faculty_survey.program_id), class: "secondary_blue_button" unless is_admin?(current_user) %> 
       </div>
     <% else %>
       <p class="body-text mb-2">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,7 +17,7 @@
         <div class="hidden sm:ml-6 sm:flex sm:space-x-4 pl-2">
           <% if user_signed_in? %>
             <div class="header_link">
-              <%= link_to "Programs", programs_path, class: "#{class_names(active: current_page?(programs_path))}" if policy(Program).index? %>
+              <%= link_to "Programs", programs_path, class: "#{class_names(active: current_page?(programs_path))}" %>
             </div>
             <div class="header_link">
               <%= link_to "Cars", cars_path, class: "#{class_names(active: current_page?(cars_path))}" if policy(Car).index? %>

--- a/app/views/programs/_program_card.html.erb
+++ b/app/views/programs/_program_card.html.erb
@@ -29,12 +29,14 @@
               <i class="fa-solid fa-pen"></i>
             <% end %>
           </div>
-          <div class="tertiary_button">
-            <%= link_to duplicate_path(program), data: { "turbo-frame": "_top" } do %>
-              Copy
-              <i class="fa-solid fa-clone"></i>
-            <% end %>
-          </div>
+          <% if is_admin?(current_user) %>
+            <div class="tertiary_button">
+              <%= link_to duplicate_path(program), data: { "turbo-frame": "_top" } do %>
+                Copy
+                <i class="fa-solid fa-clone"></i>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/programs/_program_site.html.erb
+++ b/app/views/programs/_program_site.html.erb
@@ -3,11 +3,13 @@
     <h2>Sites</h2>
   </div>
   <div>
-    <%= link_to edit_program_sites_path(@program) do %>
-      <span class="tertiary_button" %>
-        Edit Sites
-        <i class="fa-solid fa-pen" aria-hidden="true"></i>
-      </span>
+    <% if policy(@program).edit? %> 
+      <%= link_to edit_program_sites_path(@program) do %>
+        <span class="tertiary_button" %>
+          Edit Sites
+          <i class="fa-solid fa-pen" aria-hidden="true"></i>
+        </span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -10,9 +10,11 @@
           <div class="py-2">
             <%= link_to 'Edit Program', program_data_path(@program), class: "primary_button" %>
           </div>
-          <div class="py-2">
-            <%= link_to 'Students List', program_students_path(@program), class: "secondary_blue_button" %>
-          </div>
+          <% if policy(Student).update_student_list? %>
+            <div class="py-2">
+              <%= link_to 'Students List', program_students_path(@program), class: "secondary_blue_button" %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/programs/students/index.html.erb
+++ b/app/views/programs/students/index.html.erb
@@ -5,10 +5,12 @@
     </div>
     <div class="flex flex-row justify-between gap-2">
       <div>
-        <% if @student_program.not_course %>
-          <%= link_to 'Update Student List', add_students_path(@student_program), class: "secondary_blue_button" %>
-        <% else %>
-          <%= link_to 'Update Student List', update_student_list_path(@student_program), class: "secondary_blue_button" %>
+        <% if policy(Student).update_student_list? %>
+          <% if @student_program.not_course %>
+            <%= link_to 'Update Student List', add_students_path(@student_program), class: "secondary_blue_button" %>
+          <% else %>
+            <%= link_to 'Update Student List', update_student_list_path(@student_program), class: "secondary_blue_button" %>
+          <% end %>
         <% end %>
       </div>
       <div>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -35,7 +35,7 @@
     <div class="body-lg-text ml-2">
       <% @programs.each do |program| %>
         <div>
-          <% if policy(Program).edit? %>
+          <% if policy(program).edit? %>
             <%= link_to program.display_name_with_title, program_path(program), class: "link_to" %>
           <% else %>
             <%= program.display_name_with_title %>


### PR DESCRIPTION
The PR can redirect a faculty to edit a program (created after the faculty completed a survey) or directly to Add Sites to Program pages.
To give faculty access to a program where the faculty is an instructor I edited the pundit context:

- in the application_controller created method pundit_user adding program_id to the current_user to path the program to policies where it's needed
- in the application_policy updated initializer adding :program to it
- deleted initializers from all other policies (they should not be there from the beginning unless they are different than the default initializer)
- created another site_policy in the program namespace to use it when authorization is needed for a program and site at the same time
- changed  site authorization form 'authorize @site' to 'authorize([@site_program, @site])' where needed
- added helpers methods to aplication_helper and policies to check if a faculty is an instructor (to allow edit program) or manager (to allow see programs)
- - added policy checks to views to allow/deny faculty access to pages

Also, in the survey.rb and config_questions_controoler.rb I fixed errors that were missed in the previous PR.

Number of files in the PR: 4 controllers, 1 helper, 2 models,  16 policies (deleted initializer), 7 views, 1 header