### PR TITLE
LRA-584-lsa-ride-share-make-tweak-to-the-send-grid-config-for-preproduction-stuffs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+gem 'letter_opener_web'
+
 # Use OmniAuth gems to implement Shibboleth SAML authentication
 gem 'omniauth-saml', '~> 2.1'
 gem "omniauth-rails_csrf_protection"
@@ -75,6 +77,5 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'annotate', '~> 3.2'
-  gem 'letter_opener_web', '~> 2.0'
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   ldap_lookup (~> 0.1.6)
-  letter_opener_web (~> 2.0)
+  letter_opener_web
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1)
   pg (~> 1.1)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,12 +37,11 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Devise setting - Ensure you have defined default url options
-  # host = 'http://localhost:3000'
-  host = 'https://rideshare-staging.lsa.umich.edu/'
+  host = 'http://localhost:3000'
   config.action_mailer.default_url_options = { host: host }
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -62,20 +62,14 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "art_survey_production"
 
-  config.action_mailer.perform_caching = false
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
   host = 'https://rideshare-staging.lsa.umich.edu/'
   config.action_mailer.default_url_options = { host: host }
-  ActionMailer::Base.smtp_settings = {
-    :address        => 'smtp.sendgrid.net',
-    :port           => '587',
-    :authentication => :plain,
-    :user_name      => 'apikey',
-    :password       => ENV['SENDGRID_API_KEY'],
-    :domain         => 'umich.edu',
-    :enable_starttls_auto => true
-  }
+  config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+
+  #letter_opener settings
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "static_pages#home"
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? || Rails.env.staging?
   
   get 'faculty_surveys/faculty_index', to: 'faculty_surveys#faculty_index', as: :faculty_index
   resources :faculty_surveys do


### PR DESCRIPTION
While documenting the Mailer setup in the Rails Playbook I became aware of configurations that will protect from accidentally sending emails to recipients if we use "real" email addresses.

In Development and Staging the letter_opener_web interface will be mounted and the emails will be viewable in the letter_opener interface and NOT sent to recipients.

In Production emails will be sent out via the SendGrid API to teh actual recipient