### PR TITLE
Lra 577 lsa ride share faculty survey review changes

### DIFF
--- a/app/controllers/faculty_surveys_controller.rb
+++ b/app/controllers/faculty_surveys_controller.rb
@@ -13,7 +13,7 @@ class FacultySurveysController < ApplicationController
     else
       @faculty_surveys = FacultySurvey.where(unit_id: @units)
     end
-    @faculty_surveys = @faculty_surveys.data(params[:term_id])
+    @faculty_surveys = @faculty_surveys.data(params[:term_id]).order(created_at: :desc)
     authorize @faculty_surveys
   end
 
@@ -51,7 +51,7 @@ class FacultySurveysController < ApplicationController
     end
     if @faculty_survey.save
       add_config_questions(@faculty_survey)
-      redirect_to faculty_surveys_path, notice: "Faculty survey was successfully created." + result['note']
+      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully created." + result['note']
     else
       render :new, status: :unprocessable_entity
     end
@@ -71,7 +71,7 @@ class FacultySurveysController < ApplicationController
       end
     end
     if @faculty_survey.save
-      redirect_to faculty_surveys_path, notice: "Faculty survey was successfully updated."
+      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully updated."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/faculty_surveys/_form.html.erb
+++ b/app/views/faculty_surveys/_form.html.erb
@@ -53,7 +53,7 @@
       <%= form.submit 'Update Faculty Survey', class: "primary_button" %>
     <% end %>
   </div>
-  <%= link_to faculty_surveys_path do %>
+  <%= link_to faculty_surveys_path(:term_id => faculty_survey.term_id) do %>
     <span class="tertiary_button">Cancel
       <i class="fa fa-times" aria-hidden="true"></i>
     </span>

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -19,10 +19,12 @@
     <%= form.text_field :title, required: true, placeholder: "Title", class: "input_text_field" %>
   </div>
 
-  <div class="my-5">
-    <%= form.label :unit_id, 'Unit *', class: "fancy_label" %>
-    <%= form.collection_select :unit_id, @units, :id, :name, { required: true }, { class: "input_text_field" } %>
-  </div>
+  <% unless is_manager?(current_user) || @units.count == 1 %>
+    <div class="my-5">
+      <%= form.label :unit_id, 'Unit *', class: "fancy_label" %>
+      <%= form.collection_select :unit_id, @units, :id, :name, { required: true }, { class: "input_text_field" } %>
+    </div>
+  <% end %>
 
   <div class="my-5">
     <%= form.label :term_id, 'Term *', class: "fancy_label" %>


### PR DESCRIPTION
Edited the code according to Jessica's testing notes for the LRA-577.

- sorted faculty surveys so that the newest survey is on top versus the bottom
- added term_id parameter to the redirect command in the create/update survey methods to redirect to the list of surveys for the term that the survey was created not to the current term list (there is no faculty survey Show page)
- the same for the Cancel button in faculty_syrveys/_form.html.erb
- in the programs/_form display the unit list only if the user is not a manager (but an admin), and is that admin belongs to more then one unit

