### PR TITLE
add unit_id to form when there is only one unit

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -3,7 +3,7 @@ class ProgramsController < ApplicationController
 
   before_action :set_program, except: %i[ index new create]
   before_action :set_units
-  before_action :set_terms, only: %i[ duplicate new edit ]
+  before_action :set_terms, only: %i[ duplicate new edit create]
 
   include ApplicationHelper
 

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -24,6 +24,8 @@
       <%= form.label :unit_id, 'Unit *', class: "fancy_label" %>
       <%= form.collection_select :unit_id, @units, :id, :name, { required: true }, { class: "input_text_field" } %>
     </div>
+  <% else %>
+    <%= form.hidden_field :unit_id, value: @units[0].id %>
   <% end %>
 
   <div class="my-5">


### PR DESCRIPTION
There was a bug in the program form.
In case the program was created by an admin who belongs to one unit, the form was missing the unit_id.
If there are multiple units the form has a drop-down list to choose from.

I added 'before_action :set_terms' to create because terms are needed in case the create method wants to display errors