### PR TITLE
Lra 597 lsa ride share add default reservation start and end time to unit preferences

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -52,6 +52,9 @@ class ReservationsController < ApplicationController
   end
 
   def get_available_cars
+    if params[:unit_id].present?
+      @unit_id = params[:unit_id]
+    end
     if params[:day_start].present?
       @day_start = params[:day_start].to_date
     end
@@ -68,7 +71,7 @@ class ReservationsController < ApplicationController
       @reserv_begin = Time.zone.parse(params[:day_start] + " " + params[:time_start]).to_datetime
       @reserv_end = Time.zone.parse(params[:day_start] + " " + params[:time_end]).to_datetime
       range = @reserv_begin..@reserv_end
-      @cars = available_cars(@cars, range)
+      @cars = available_cars(@cars, range, @unit_id)
     end
     authorize Reservation
   end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -6,7 +6,15 @@ class ReservationsController < ApplicationController
 
   # GET /reservations or /reservations.json
   def index
-    @reservations = Reservation.all
+    if current_user.unit_ids.count == 1
+      @unit_id = current_user.unit_ids[0]
+      @reservations = Reservation.where(program: Program.where(unit_id: @unit_id))
+    elsif params[:unit_id].present?
+      @unit_id = params[:unit_id]
+      @reservations = Reservation.where(program: Program.where(unit_id: @unit_id))
+    else
+      @reservations = Reservation.all
+    end
     authorize @reservations
   end
 
@@ -16,6 +24,7 @@ class ReservationsController < ApplicationController
 
   # GET /reservations/new
   def new
+    @unit_id = params[:unit_id].to_i
     if params[:day_start].present?
       @day_start = params[:day_start].to_date
     else
@@ -26,7 +35,7 @@ class ReservationsController < ApplicationController
     @cars = Car.all
     @number_of_seats = 1..Car.maximum(:number_of_seats)
     @reservation = Reservation.new
-    @reservation.start_time = @day_start 
+    @reservation.start_time = @day_start
     authorize @reservation
   end
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -3,6 +3,7 @@ class ReservationsController < ApplicationController
   before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger ]
   before_action :set_terms_and_units
   before_action :set_programs
+  before_action :set_cars, only: %i[ new edit get_available_cars ]
 
   # GET /reservations or /reservations.json
   def index
@@ -36,7 +37,6 @@ class ReservationsController < ApplicationController
     end
     @students = []
     @sites = []
-    @cars = Car.all
     @number_of_seats = 1..Car.maximum(:number_of_seats)
     @reservation = Reservation.new
     @reservation.start_time = @day_start
@@ -48,7 +48,6 @@ class ReservationsController < ApplicationController
     @sites = @reservation.program.sites
     @number_of_seats = 1..Car.maximum(:number_of_seats)
     @day_start = @reservation.start_time.to_date
-    @cars = Car.all
   end
 
   def get_available_cars
@@ -59,7 +58,7 @@ class ReservationsController < ApplicationController
       @day_start = params[:day_start].to_date
     end
     if params[:number].present?
-      @cars = Car.where("number_of_seats >= ?", params[:number])
+      @cars = @cars.where("number_of_seats >= ?", params[:number])
     end
     if params[:time_start].present?
       @time_start = params[:time_start]
@@ -91,7 +90,7 @@ class ReservationsController < ApplicationController
       @sites = []
       @students = []
       @number_of_seats = 1..Car.maximum(:number_of_seats)
-      @cars = Car.all
+      @cars = Car.data(params[:unit_id])
       @day_start = params[:day_start]
       render :new, status: :unprocessable_entity
     end
@@ -176,6 +175,10 @@ class ReservationsController < ApplicationController
 
     def set_programs
       @programs = Program.where(unit_id: current_user.unit_ids)
+    end
+
+    def set_cars
+      @cars = Car.data(params[:unit_id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -24,7 +24,11 @@ class ReservationsController < ApplicationController
 
   # GET /reservations/new
   def new
-    @unit_id = params[:unit_id].to_i
+    if params[:unit_id].present?
+      @unit_id = params[:unit_id]
+    else
+      redirect_to reservations_path, notice: "You must select a unit first."
+    end
     if params[:day_start].present?
       @day_start = params[:day_start].to_date
     else

--- a/app/controllers/unit_preferences_controller.rb
+++ b/app/controllers/unit_preferences_controller.rb
@@ -1,16 +1,17 @@
 class UnitPreferencesController < ApplicationController
   before_action :auth_user
   before_action :set_units
+  before_action :set_pref_types, only: %i[ index new edit create update]
 
   # GET /unit_preferences or /unit_preferences.json
   def index
     @unit_preference = UnitPreference.new
-    @unit_preferences = UnitPreference.distinct.order(:name).pluck(:name, :description)
+    @unit_preferences = UnitPreference.distinct.order(:name).pluck(:name, :description, :pref_type)
     authorize UnitPreference
   end
 
   def unit_prefs
-    @unit_prefs = UnitPreference.where(unit_id: current_user.unit_ids).order(:description)
+    @unit_prefs = UnitPreference.where(unit_id: current_user.unit_ids).order(:pref_type, :description)
     authorize @unit_prefs
   end
 
@@ -22,7 +23,13 @@ class UnitPreferencesController < ApplicationController
       params[:unit_prefs].each do |unit, p|
         unit_id = unit.to_i
         p.each do |k, v|
-          UnitPreference.find_by(unit_id: unit_id, name: k).update(value: true)
+          pref = UnitPreference.find_by(unit_id: unit_id, name: k)
+          if pref.pref_type == 'boolean'
+            pref.update(on_off: true)
+          end
+          if pref.pref_type == 'time' || pref.pref_type == 'string'
+            pref.update(value: v)
+          end
         end
       end
     end
@@ -44,13 +51,13 @@ class UnitPreferencesController < ApplicationController
       authorize @unit_preference
       @unit_preference.unit_id = unit.id
       unless @unit_preference.save
-        @unit_preferences = UnitPreference.distinct.pluck(:name, :description)
+        @unit_preferences = UnitPreference.distinct.pluck(:name, :description, :pref_type)
         return
       end
     end
     flash.now[:notice] =  "Unit preference was successfully created."
     @unit_preference = UnitPreference.new
-    @unit_preferences = UnitPreference.distinct.pluck(:name, :description)
+    @unit_preferences = UnitPreference.distinct.pluck(:name, :description, :pref_type)
   end
 
   def delete_preference
@@ -73,8 +80,12 @@ class UnitPreferencesController < ApplicationController
       @units = Unit.where(id: current_user.unit_ids)
     end
 
+    def set_pref_types
+      @pref_types = UnitPreference.pref_types.keys
+    end
+
     # Only allow a list of trusted parameters through.
     def unit_preference_params
-      params.require(:unit_preference).permit(:name, :description, :value, :unit_id)
+      params.require(:unit_preference).permit(:name, :description, :on_off, :value, :pref_type, :unit_id)
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,15 +100,10 @@ module ApplicationHelper
 
   def available_ranges(car, day, unit_id)
     # time renges when the car is available on the day
-    t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
-    t_begin = Time.parse(t_begin).strftime("%H").to_i
-    t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
-    t_end = Time.parse(t_end).strftime("%H").to_i
-    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
-    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    times = show_time_begin_end(day, unit_id)
+    day_begin  = times[0]
+    day_end  = times[1]
     car_available = []
-    # day_begin = DateTime.new(day.year, day.month, day.day, 8, 0, 0, 'EDT')
-    # day_end = DateTime.new(day.year, day.month, day.day, 17, 0, 0, 'EDT')
     space_begin = day_begin
     car_day_reserv = car.reservations.where("start_time BETWEEN ? AND ?", day.beginning_of_day, day.end_of_day).order(:start_time)
     if car_day_reserv.present?
@@ -133,6 +128,16 @@ module ApplicationHelper
     return car_available
   end
 
+  def show_time_begin_end(day, unit_id)
+    t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
+    t_begin = Time.parse(t_begin).strftime("%H").to_i
+    t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
+    t_end = Time.parse(t_end).strftime("%H").to_i
+    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    return [day_begin, day_end]
+  end
+
   def show_time_range(day_range)
     "#{day_range.begin.strftime("%I:%M%p")} - #{day_range.end.strftime("%I:%M%p")}"
   end
@@ -155,12 +160,9 @@ module ApplicationHelper
 
   def available_time(day, cars, unit_id)
     # array of time with 15 minutes step available to reserve cars
-    t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
-    t_begin = Time.parse(t_begin).strftime("%H").to_i
-    t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
-    t_end = Time.parse(t_end).strftime("%H").to_i
-    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
-    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    times = show_time_begin_end(day, unit_id)
+    day_begin  = times[0]
+    day_end  = times[1]
     day_times_with_15_min_steps = (day_begin.to_i..day_end.to_i).to_a.in_groups_of(15.minutes).collect(&:first).collect { |t| Time.at(t) }
     available_times_begin = []
     available_times_end = []

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,11 +98,17 @@ module ApplicationHelper
     Program.all.map { |p| p.all_managers.include?(user.uniqname) }.any?
   end
 
-  def available_ranges(car, day)
+  def available_ranges(car, day, unit_id)
     # time renges when the car is available on the day
+    t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
+    t_begin = Time.parse(t_begin).strftime("%H").to_i
+    t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
+    t_end = Time.parse(t_end).strftime("%H").to_i
+    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
     car_available = []
-    day_begin = DateTime.new(day.year, day.month, day.day, 8, 0, 0, 'EDT')
-    day_end = DateTime.new(day.year, day.month, day.day, 17, 0, 0, 'EDT')
+    # day_begin = DateTime.new(day.year, day.month, day.day, 8, 0, 0, 'EDT')
+    # day_end = DateTime.new(day.year, day.month, day.day, 17, 0, 0, 'EDT')
     space_begin = day_begin
     car_day_reserv = car.reservations.where("start_time BETWEEN ? AND ?", day.beginning_of_day, day.end_of_day).order(:start_time)
     if car_day_reserv.present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,7 @@ module ApplicationHelper
   end
 
   def unit_use_faculty_survey?(unit_id)
-    UnitPreference.where(unit_id: unit_id, name: "faculty_survey").present? && UnitPreference.where(unit_id: unit_id, name: "faculty_survey").pluck(:value).include?(true)
+    UnitPreference.where(unit_id: unit_id, name: "faculty_survey").present? && UnitPreference.where(unit_id: unit_id, name: "faculty_survey").pluck(:on_off).include?(true)
   end
 
   def faculty_has_survey?(current_user)
@@ -147,11 +147,15 @@ module ApplicationHelper
     end
   end
 
-  def available_time(day, cars)
+  def available_time(day, cars, unit_id)
     # array of time with 15 minutes step available to reserve cars
-    day_begin = DateTime.new(day.year, day.month, day.day, 8, 0, 0, 'EDT')
-    day_end = DateTime.new(day.year, day.month, day.day, 17, 0, 0, 'EDT')
-    day_times_with_15_min_steps = (day_begin.to_i..day_end.to_i).to_a.in_groups_of(15.minutes).collect(&:first).collect { |t| Time.at(t) } 
+    t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
+    t_begin = Time.parse(t_begin).strftime("%H").to_i
+    t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
+    t_end = Time.parse(t_end).strftime("%H").to_i
+    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    day_times_with_15_min_steps = (day_begin.to_i..day_end.to_i).to_a.in_groups_of(15.minutes).collect(&:first).collect { |t| Time.at(t) }
     available_times_begin = []
     available_times_end = []
     day_reservations = Reservation.where("start_time BETWEEN ? AND ?", day.beginning_of_day, day.end_of_day).order(:start_time)
@@ -247,5 +251,7 @@ module ApplicationHelper
       ['Wyoming', 'WY']
     ]
   end
+
+  def time_list = ["12:00AM"] + (1..11).map {|h| "#{h}:00AM"}.to_a + ["12:00PM"] + (1..11).map {|h| "#{h}:00PM"}.to_a
 
 end

--- a/app/javascript/controllers/reservation_controller.js
+++ b/app/javascript/controllers/reservation_controller.js
@@ -102,7 +102,7 @@ export default class extends Controller {
 
   availableCars(){
     console.log("availableCars")
-    var unit_id =this.unitTarget.value
+    var unit_id = this.unitTarget.value
     var day_start = this.day_startTarget.value
     var number = this.numberTarget.value
     var time_start = this.time_startTarget.value

--- a/app/javascript/controllers/reservation_controller.js
+++ b/app/javascript/controllers/reservation_controller.js
@@ -102,6 +102,7 @@ export default class extends Controller {
 
   availableCars(){
     console.log("availableCars")
+    var unit_id =this.unitTarget.value
     var day_start = this.day_startTarget.value
     var number = this.numberTarget.value
     var time_start = this.time_startTarget.value
@@ -111,7 +112,7 @@ export default class extends Controller {
     console.log(time_start)
     console.log(time_end)
 
-    get(`/reservations/get_available_cars/${day_start}/${number}/${time_start}/${time_end}`, {
+    get(`/reservations/get_available_cars/${unit_id}/${day_start}/${number}/${time_start}/${time_end}`, {
       responseKind: "turbo-stream"
     })
   }

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -34,6 +34,8 @@ class Car < ApplicationRecord
   
   enum :status, [:available, :unavailable], prefix: true, scopes: true
 
+  scope :data, ->(unit_id) { unit_id.present? ? where(unit_id: unit_id) : all }
+
   def last_vehicle_report
     VehicleReport.where(reservation_id: self.reservations.ids).present? ?
     VehicleReport.where(reservation_id: self.reservations.ids).order(:updated_at).last :

--- a/app/models/unit_preference.rb
+++ b/app/models/unit_preference.rb
@@ -19,7 +19,7 @@ class UnitPreference < ApplicationRecord
   enum :pref_type, [:boolean, :string, :time], prefix: true, scopes: true
 
   validates :name, uniqueness: { scope: :unit_id, message: "should be unique." }
-  validates_presence_of :pref_type
+  validates_presence_of :pref_type, :description
 
   def name=(value)
     super(value.try(:strip))

--- a/app/models/unit_preference.rb
+++ b/app/models/unit_preference.rb
@@ -7,14 +7,19 @@
 #  description :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  value       :boolean
+#  on_off      :boolean
+#  value       :string
+#  pref_type   :integer
 #  unit_id     :bigint
 #
 
 class UnitPreference < ApplicationRecord
   belongs_to :unit
 
+  enum :pref_type, [:boolean, :string, :time], prefix: true, scopes: true
+
   validates :name, uniqueness: { scope: :unit_id, message: "should be unique." }
+  validates_presence_of :pref_type
 
   def name=(value)
     super(value.try(:strip))

--- a/app/views/reservations/_available_cars.html.erb
+++ b/app/views/reservations/_available_cars.html.erb
@@ -8,7 +8,7 @@
   <ul role="list" class="grid grid-cols-2 gap-4 sm:grid-cols-2 lg:grid-cols-4 mt-4">
     <% @cars.each do |car| %>
       <li class="col-span-1 bg-white rounded-lg shadow-md divide-y divide-gray-400 px-2 place-items-stretch bg-white border border-gray-300 rounded-lg">
-        <%= render 'car_card', car: car, day: @day_start %>
+        <%= render 'car_card', car: car, day: @day_start, unit_id: @unit_id %>
       </li>
     <% end %>
   </ul>

--- a/app/views/reservations/_car_card.html.erb
+++ b/app/views/reservations/_car_card.html.erb
@@ -4,7 +4,7 @@
       <%= car.car_number %> - <%= car.number_of_seats %> seats
     </div>
     <div>
-      <% available_ranges(car, day).each do |range| %>
+      <% available_ranges(car, day, unit_id).each do |range| %>
         <div>
           <%= range %>
         </div>

--- a/app/views/reservations/_form.html.erb
+++ b/app/views/reservations/_form.html.erb
@@ -11,31 +11,13 @@
     </div>
   <% end %>
 
-  <% if is_admin?(current_user) && current_user.unit_ids.count > 1 %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-      <div>
-        <%= form.label :unit_id, 'Unit *', class: "fancy_label" %>
-        <%= select_tag "unit_id", options_from_collection_for_select(@units, :id, :name, selected: params[:unit_id]), include_blank: "Select ...", class: "input_text_field",
-          "data-reservation-target": "unit" %>
-      </div>
-      <div>
-        <%= form.label :term_id, 'Term *', class: "fancy_label" %>
-        <%= select_tag "term_id", options_from_collection_for_select(@terms, :id, :name, selected: params[:term_id]), include_blank: "Select ...", class: "input_text_field",
-          "data-reservation-target": "term", "data-action": "change->reservation#changePrograms" %>
-      </div>
-    </div>
-  <% elsif is_admin?(current_user) && current_user.unit_ids.count == 1 %>
-    <%= form.label :unit_id, 'Unit *', class: "hidden" %>
-    <input type="hidden" id="unit_id" name="unit_id" value=<%= current_user.unit_ids[0] %> data-reservation-target="unit">
-    <div>
-      <%= form.label :term_id, 'Term *', class: "fancy_label" %>
-      <%= select_tag "term_id", options_from_collection_for_select(@terms, :id, :name, selected: params[:term_id]), include_blank: "Select ...", class: "input_text_field",
-        "data-reservation-target": "term", "data-action": "change->reservation#changePrograms" %>
-    </div>
-  <% else %>
-    <%= form.label :unit_id, 'Unit *', class: "hidden" %>
-    <input type="hidden" id="unit_id" name="unit_id" value=<%= Student.find_by(uniqname: current_user.uniqname).program.unit_id %> data-reservation-target="unit">
-  <% end %>
+  <%= form.label :unit_id, 'Unit *', class: "hidden" %>
+  <input type="hidden" id="unit_id" name="unit_id" value=<%= @unit_id %> data-reservation-target="unit">
+  <div>
+    <%= form.label :term_id, 'Term *', class: "fancy_label" %>
+    <%= select_tag "term_id", options_from_collection_for_select(@terms, :id, :name, selected: params[:term_id]), include_blank: "Select ...", class: "input_text_field",
+      "data-reservation-target": "term", "data-action": "change->reservation#changePrograms" %>
+  </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
     <div>
@@ -67,13 +49,13 @@
 
     <div>
       <%= form.label :time_start, 'Start Time *', class: "fancy_label" %>
-      <%= select_tag "time_start", options_for_select(available_time(@day_start, @cars)[:begin]), class: "input_text_field",
+      <%= select_tag "time_start", options_for_select(available_time(@day_start, @cars, @unit_id)[:begin]), class: "input_text_field",
         "data-reservation-target": "time_start", "data-action": "change->reservation#availableCars" %>
     </div>
 
     <div>
       <%= form.label :time_end, 'End Time *', class: "fancy_label" %>
-      <%= select_tag "time_end", options_for_select(available_time(@day_start, @cars)[:end]), class: "input_text_field",
+      <%= select_tag "time_end", options_for_select(available_time(@day_start, @cars, @unit_id)[:end]), class: "input_text_field",
         "data-reservation-target": "time_end", "data-action": "change->reservation#availableCars" %>
     </div>
   </div>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -1,40 +1,53 @@
-<div class="w-full">
+<div class="w-full" data-controller='autosubmit'>
   <div class="pb-4">
     <h1 class="mb-2">Reservations</h1>
   </div>
-  <%= turbo_frame_tag 'calendar' do %>
-    <%= month_calendar(events: @reservations) do |date, reservations| %>
-      <div class="day-header">
-        <%= date.mday %>
+  <%= form_with url: reservations_path, method: :get, class: "", data: { autosubmit_target: "form", turbo_frame: "unit-calendar" } do |form| %>
+    <% if current_user.unit_ids.count > 1 %>
+      <div class="my-2">
+        <label for="unit_id" class="fancy_label">Select a Unit</label>
+        <%= select_tag "unit_id", options_from_collection_for_select(@units, :id, :name, selected: params[:unit_id]), include_blank: "All Units", class: "filter_select w-48",
+          :"data-action" => "change->autosubmit#search" %>
       </div>
-
-      <div class="flex flex-col justify-between">
-        <% reservations.each do |reservation| %>
-          <div>
-            <%= link_to reservation.display_name, reservation_path(reservation.id) %>
-            <p>
-              From: 
-              <%= show_date_time(reservation.start_time) %>
-            </p>
-            <p>
-              To: 
-              <%= show_date_time(reservation.end_time) %>
-            </p>
-          </div>
-        <% end %>
-        <div class="">
-          <%= link_to new_reservation_path(:day_start => date) do %>
-            <i class="fa fa-plus" aria-hidden="true"></i>
-            <span class="tertiary_button -m-4">
-              Add Reservation
-            </span>
-          <% end %>
-        </div>
-      </div>
+    <% else %>
+      <%= form.label :unit_id, 'Unit *', class: "hidden" %>
+      <input type="hidden" id="unit_id" name="unit_id" value=<%= @unit_id %>>
     <% end %>
-  <% end %>
 
-  <div id="reservations" class="min-w-full mt-2">
-    <%= render 'listing' %>
-  </div>
+    <%= turbo_frame_tag 'unit-calendar' do %>
+      <%= month_calendar(events: @reservations) do |date, reservations| %>
+        <div class="day-header">
+          <%= date.mday %>
+        </div>
+
+        <div class="flex flex-col justify-between">
+          <% reservations.each do |reservation| %>
+            <div>
+              <%= link_to reservation.display_name, reservation_path(reservation.id) %>
+              <p>
+                From: 
+                <%= show_date_time(reservation.start_time) %>
+              </p>
+              <p>
+                To: 
+                <%= show_date_time(reservation.end_time) %>
+              </p>
+            </div>
+          <% end %>
+          <div class="">
+            <%= link_to new_reservation_path(:unit_id => @unit_id, :day_start => date) do %>
+              <i class="fa fa-plus" aria-hidden="true"></i>
+              <span class="tertiary_button -m-4">
+                Add Reservation
+              </span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div id="reservations" class="min-w-full mt-2">
+      <%= render 'listing' %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/unit_preferences/_form.html.erb
+++ b/app/views/unit_preferences/_form.html.erb
@@ -21,6 +21,11 @@
       <%= form.text_field :description, required: true, class: "input_text_field" %>
     </div>
 
+    <div class="my-5">
+      <%= form.label :pref_type, 'Type *', class: "fancy_label" %>
+      <%= form.select :pref_type, @pref_types.map{ |key| [key.titleize, key] }, { include_blank: "Select ...", required: true }, { class: "input_text_field" } %>
+    </div>
+
     <div class="inline">
       <%= form.submit 'Create Unit Preference', class: "secondary_blue_button" %>
     </div>

--- a/app/views/unit_preferences/_preference_list.html.erb
+++ b/app/views/unit_preferences/_preference_list.html.erb
@@ -5,17 +5,21 @@
         <tr>
           <th class="header_th">Name</th>
           <th class="header_th">Description</th>
+          <th class="header_th">Type</th>
           <th class="header_th"></th>
         </tr>
       </thead>
       <tbody>
-        <% @unit_preferences.each do |name, descr| %>
+        <% @unit_preferences.each do |name, descr, pref_type| %>
           <tr class="mi_tbody_tr">
             <td class="mi_tbody_td">
               <%= name %>
             </td>
             <td class="mi_tbody_td">
               <%= descr %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= pref_type %>
             </td>
             <td>
               <%= link_to 'Delete', delete_preference_path(name), data: { turbo_confirm: 'Are you sure?', turbo_method: :get }, class: "link_to" %>

--- a/app/views/unit_preferences/unit_prefs.html.erb
+++ b/app/views/unit_preferences/unit_prefs.html.erb
@@ -7,9 +7,18 @@
         <% @unit_prefs.where(unit_id: unit).each do |pref| %>
           <%= fields_for 'unit_prefs[]' do %>
             <div>
-            <%= label_tag("unit_prefs[#{unit.id}][#{pref.name}]", nil, class: "hidden") %>
-            <%= check_box_tag "unit_prefs[#{unit.id}][#{pref.name}]", 1, pref.value, class: "check_box" %>
-            <span class="check_box_text"><%= pref.description %></span>
+              <% if pref.pref_type == "boolean" %>
+                <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="hidden"><%= pref.description %></label>
+                <%= check_box_tag "unit_prefs[#{unit.id}][#{pref.name}]", 1, pref.on_off, class: "check_box" %>
+                <span class="check_box_text"><%= pref.description %></span>
+              <% elsif pref.pref_type == "boolean" %>
+                <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="fancy_label"><%= pref.description %></label>
+                <%= text_field_tag("unit_prefs[#{unit.id}][#{pref.name}]", pref.value, {class: "input_text_field"}) %>
+              <% elsif pref.pref_type == "time" %>
+                <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="fancy_label"><%= pref.description %> *</label>
+                <%#= text_field_tag("unit_prefs[#{unit.id}][#{pref.name}]", pref.value, {required: true, class: "input_text_field"}) %>
+                <%= select_tag "unit_prefs[#{unit.id}][#{pref.name}]", options_for_select(time_list, pref.value), class: "input_text_field" %>
+              <% end %>
             </div>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   # get '/vehicle_reports/:reports_ids', to: 'vehicle_reports#index', as: 'vehicle_reports'
 
   resources :reservations
-  get '/reservations/get_available_cars/:day_start/:number/:time_start/:time_end', to: 'reservations#get_available_cars'
+  get '/reservations/get_available_cars/:unit_id/:day_start/:number/:time_start/:time_end', to: 'reservations#get_available_cars'
   get '/reservations/add_passengers/:id', to: 'reservations#add_passengers', as: :add_passengers
   get '/reservations/add_drivers/:id', to: 'reservations#add_drivers', as: :add_drivers
   delete 'reservations/:id/:student_id', to: 'reservations#remove_passenger', as: :remove_passenger

--- a/db/migrate/20230602214311_edit_fields_in_unit_preferences.rb
+++ b/db/migrate/20230602214311_edit_fields_in_unit_preferences.rb
@@ -1,0 +1,7 @@
+class EditFieldsInUnitPreferences < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :unit_preferences, :value, :on_off
+    add_column :unit_preferences, :value, :string
+    add_column :unit_preferences, :pref_type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_26_140558) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_214311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -243,10 +243,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_26_140558) do
   create_table "unit_preferences", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.boolean "value"
+    t.boolean "on_off"
     t.bigint "unit_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "value"
+    t.integer "pref_type"
     t.index ["unit_id"], name: "index_unit_preferences_on_unit_id"
   end
 


### PR DESCRIPTION
Start and end reservation times (the earliest pick-up and the latest drop-off times) might be different for different units.
It makes sense to create unit preferences for those values.

To do that 

- I edited unit_preferences table adding pref_type field (with values boolean, string, time), boolean field on_off and string field value.
- to make this work in the application the following preferences should be created:
  - name: "reservation_time_begin" with description: "The earliest time of the day to pick up cars" and type: time
  - name: "reservation_time_end" with description: "The latest time of the day to drop off cars" and type: time
  - names and types should be exactly as I wrote, descriptions may be different
  - after that, a unit admin should set up these references for the unit
- I added unit_id to the argument list for the available times and cars helper methods
- I moved the unit select field from the reservation form to the previous screen. First, select a unit, then reservation. We need to know the unit to make the correct time drop-down list in the reservation form. Now the form has one field less and it looks the same for every admin (with one unit or multiple). 