### PR TITLE
LRA-662 LSA RideShare - Do not allow users to edit accounts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:saml]
 
   attr_accessor :membership, :unit_ids


### PR DESCRIPTION
Right now users can go here: https://rideshare-staging.lsa.umich.edu/users/edit and they should not.

The solution I found is to remove :registerable from the User model. That will remove all 'registration' routes from the application.
In this case, the URL '.../users/edit' will display the error message

No route matches [GET] "/users/edit"