### PR TITLE
Lra 647 lsa ride share reservation confirmation add students names to email

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,6 +1,6 @@
 class ReservationsController < ApplicationController
   before_action :auth_user
-  before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger ]
+  before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger finish_reservation]
   before_action :set_terms_and_units
   before_action :set_programs
   before_action :set_cars, only: %i[ new get_available_cars ]
@@ -154,8 +154,8 @@ class ReservationsController < ApplicationController
     @reservation.reserved_by = current_user.id
     authorize @reservation
     if @reservation.save
-      ReservationMailer.with(reservation: @reservation).car_reservation_confirmation.deliver_now
-      ReservationMailer.with(reservation: @reservation).car_reservation_created.deliver_now
+      # ReservationMailer.with(reservation: @reservation).car_reservation_confirmation.deliver_now
+      # ReservationMailer.with(reservation: @reservation).car_reservation_created.deliver_now
       @students = @reservation.program.students 
       redirect_to add_drivers_path(@reservation), notice: "Reservation was successfully created. Please add drivers."
     else
@@ -266,6 +266,12 @@ class ReservationsController < ApplicationController
   def remove_passenger
     @reservation.passengers.delete(Student.find(params[:student_id]))
     add_passengers
+  end
+
+  def finish_reservation
+    ReservationMailer.with(reservation: @reservation).car_reservation_confirmation.deliver_now
+    ReservationMailer.with(reservation: @reservation).car_reservation_created.deliver_now
+    redirect_to reservation_path(@reservation)
   end
 
   # DELETE /reservations/1 or /reservations/1.json

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -154,8 +154,6 @@ class ReservationsController < ApplicationController
     @reservation.reserved_by = current_user.id
     authorize @reservation
     if @reservation.save
-      # ReservationMailer.with(reservation: @reservation).car_reservation_confirmation.deliver_now
-      # ReservationMailer.with(reservation: @reservation).car_reservation_created.deliver_now
       @students = @reservation.program.students 
       redirect_to add_drivers_path(@reservation), notice: "Reservation was successfully created. Please add drivers."
     else

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,6 +1,6 @@
 class ReservationsController < ApplicationController
   before_action :auth_user
-  before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger finish_reservation]
+  before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger finish_reservation update_passengers]
   before_action :set_terms_and_units
   before_action :set_programs
   before_action :set_cars, only: %i[ new get_available_cars ]
@@ -200,7 +200,7 @@ class ReservationsController < ApplicationController
     end
     if params[:reservation][:driver_id].present?
       if @reservation.update(reservation_params)
-        redirect_to add_passengers_path(@reservation)
+        redirect_to add_passengers_path(@reservation, :edit => params[:edit])
         return
       else
         flash.now[:alert] = "error"
@@ -272,6 +272,10 @@ class ReservationsController < ApplicationController
     ReservationMailer.with(reservation: @reservation).car_reservation_confirmation.deliver_now
     ReservationMailer.with(reservation: @reservation).car_reservation_created.deliver_now
     redirect_to reservation_path(@reservation)
+  end
+
+  def update_passengers
+    redirect_to reservation_path(@reservation), notice: "Passengers list was updated"
   end
 
   # DELETE /reservations/1 or /reservations/1.json

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -54,6 +54,10 @@ class ReservationPolicy < ApplicationPolicy
     update?
   end
 
+  def finish_reservation?
+    update?
+  end
+
   def destroy?
     user_in_access_group? || is_reservation_driver?
   end

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -58,6 +58,10 @@ class ReservationPolicy < ApplicationPolicy
     update?
   end
 
+  def update_passengers?
+    update?
+  end
+
   def destroy?
     user_in_access_group? || is_reservation_driver?
   end

--- a/app/views/mailers/reservation_mailer/car_reservation_confirmation.html.erb
+++ b/app/views/mailers/reservation_mailer/car_reservation_confirmation.html.erb
@@ -18,6 +18,14 @@
         <li>VEHICLE #: <%= link_to @reservation.car.car_number, car_url(@reservation.car) %></li>
         <li>SITE: <%= link_to @reservation.site.title, site_url(@reservation.site) %> </li>
         <li>PROGRAM: <%= link_to @reservation.program.title, program_url(@reservation.program) %></li>
+        <li>DRIVER: <%= @driver_name %> </li>
+        <li>BACKUP DRIVER: <%= @backup_driver_name %> </li>
+      </ul>
+      PASSENGERS:
+      <ul>
+        <% @passengers.each do |p| %>
+          <li> <%= p %> </li>
+        <% end %>
       </ul>
     </p>
     <p>

--- a/app/views/mailers/reservation_mailer/car_reservation_created.html.erb
+++ b/app/views/mailers/reservation_mailer/car_reservation_created.html.erb
@@ -17,6 +17,14 @@
         
         <li>SITE: <%= link_to @reservation.site.title, site_url(@reservation.site) %> </li>
         <li>PROGRAM: <%= link_to @reservation.program.title, program_url(@reservation.program) %></li>
+        <li>DRIVER: <%= @driver_name %> </li>
+        <li>BACKUP DRIVER: <%= @backup_driver_name %> </li>
+      </ul>
+      PASSENGERS:
+      <ul>
+        <% @passengers.each do |p| %>
+          <li> <%= p %> </li>
+        <% end %>
       </ul>
     </p>
     <p>

--- a/app/views/reservations/_drivers.html.erb
+++ b/app/views/reservations/_drivers.html.erb
@@ -64,6 +64,8 @@
       </div>
     <% end %>
 
+    <input type="hidden" id="edit" name="edit" value=<%= params[:edit] %>>
+
     <div class="inline">
       <%= form.submit "Save and Add Passengers", class: "primary_button" %>
     </div>

--- a/app/views/reservations/add_passengers.html.erb
+++ b/app/views/reservations/add_passengers.html.erb
@@ -60,6 +60,10 @@
   </div>
 
   <div class="mt-4">
-    <%= link_to "Finish Creating Reservation", finish_reservation_path(@reservation), class: "primary_button" %>
+    <% if params["edit"] == "true" %>
+      <%= link_to "Update Passengers", update_passengers_path(@reservation), class: "primary_button" %>
+    <% else %>
+      <%= link_to "Finish Creating Reservation", finish_reservation_path(@reservation), class: "primary_button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/reservations/add_passengers.html.erb
+++ b/app/views/reservations/add_passengers.html.erb
@@ -60,6 +60,6 @@
   </div>
 
   <div class="mt-4">
-    <%= link_to "Finish Creating Reservation", reservation_path(@reservation), class: "primary_button" %>
+    <%= link_to "Finish Creating Reservation", finish_reservation_path(@reservation), class: "primary_button" %>
   </div>
 </div>

--- a/app/views/reservations/remove_passenger.turbo_stream copy.erb
+++ b/app/views/reservations/remove_passenger.turbo_stream copy.erb
@@ -1,9 +1,0 @@
-<%= render_flash_stream %>
-
-<%= turbo_stream.update "new_passenger" do %>
-  <%= render "students" %>
-<% end %>
-
-<%= turbo_stream.update "passenger_list" do %>
-  <%= render "passenger_list", locals: { reservation: @reservation} %>
-<% end %>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -42,7 +42,7 @@
             </div>
           <% end %>
           <div>
-            <%= link_to 'Edit Drivers and Passengers', add_drivers_path(:id => @reservation, :edit => true), class: "primary_button" if policy(@reservation).edit? %>
+            <%= link_to 'Edit Drivers and Passengers', add_drivers_path(@reservation, :edit => true), class: "primary_button" if policy(@reservation).edit? %>
           </div>
           <div class="my-2">
             <%= link_to reservation_path(@reservation), data: { turbo_confirm: 'Are you sure?', turbo_method: :delete} do %>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -42,7 +42,7 @@
             </div>
           <% end %>
           <div>
-            <%= link_to 'Edit Drivers and Passengers', add_drivers_path(@reservation), class: "primary_button" if policy(@reservation).edit? %>
+            <%= link_to 'Edit Drivers and Passengers', add_drivers_path(:id => @reservation, :edit => true), class: "primary_button" if policy(@reservation).edit? %>
           </div>
           <div class="my-2">
             <%= link_to reservation_path(@reservation), data: { turbo_confirm: 'Are you sure?', turbo_method: :delete} do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,8 @@ Rails.application.routes.draw do
   delete 'reservations/:id/:student_id', to: 'reservations#remove_passenger', as: :remove_passenger
   get '/reservations/day_reservations/:date', to: 'reservations#day_reservations', as: :day_reservations
   get '/reservations/:id/finish_reservation', to: 'reservations#finish_reservation', as: :finish_reservation
-  
+  get '/reservations/:id/update_passengers', to: 'reservations#update_passengers', as: :update_passengers
+
   resources :cars do
     resources :notes, module: :cars
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   get '/reservations/add_drivers/:id', to: 'reservations#add_drivers', as: :add_drivers
   delete 'reservations/:id/:student_id', to: 'reservations#remove_passenger', as: :remove_passenger
   get '/reservations/day_reservations/:date', to: 'reservations#day_reservations', as: :day_reservations
+  get '/reservations/:id/finish_reservation', to: 'reservations#finish_reservation', as: :finish_reservation
   
   resources :cars do
     resources :notes, module: :cars


### PR DESCRIPTION
Workflow to send a confirmation email with the drivers' and passengers' names after a new reservation is created and do nothing (for now) when drivers or passengers are edited.
Sending emails on editing a reservation (including drivers and passengers) will be addressed in a separate ticket.

The workflow

- Sending emails is moved from update to finish_reservation method (in reservation_controller)
- finish_reservation is called when a user clicks the [Finish Creating Reservation] button on the add passengers page
- On the reservation show page a parameter [:edit => true] is added to the Edit Drivers and Passengers button. 
- If params["edit"] == "true", the add_passengers page shows the [Update Passengers] button (instead of Finish Creating Reservation)
- when users click the [Update Passengers] button they are redirected to the show reservation page (for now; later an edit-reservation-email should be sent to users)