### PR TITLE
Lra 651 lsa ride share add students manually to all programs

### DIFF
--- a/app/controllers/concerns/student_api.rb
+++ b/app/controllers/concerns/student_api.rb
@@ -62,7 +62,7 @@ module StudentApi
     if result['success']
       if result['data']['Classes']['Class']['ClassSections']['ClassSection']['ClassStudents'].present?
         data = result['data']['Classes']['Class']['ClassSections']['ClassSection']['ClassStudents']['ClassStudent']
-        students_in_db = @student_program.students.pluck(:uniqname)
+        students_in_db = @student_program.students.registered.pluck(:uniqname)
         data.each do |student_info|
           uniqname = student_info['Uniqname']
           if students_in_db.include?(uniqname)

--- a/app/controllers/programs/students_controller.rb
+++ b/app/controllers/programs/students_controller.rb
@@ -9,7 +9,7 @@ class Programs::StudentsController < ApplicationController
     unless @student_program.not_course
       update_students(@student_program)
     end
-    @students = @student_program.students.order(:last_name)
+    @students = @student_program.students.order(registered: :desc).order(:last_name)
     authorize @students
   end
 
@@ -21,7 +21,7 @@ class Programs::StudentsController < ApplicationController
 
   def add_students
     @student = Student.new
-    @students = @student_program.students.order(:last_name)
+    @students = @student_program.students.order(registered: :desc).order(:last_name)
     authorize Student
   end
 
@@ -171,7 +171,7 @@ class Programs::StudentsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def student_params
-      params.require(:student).permit(:uniqname, :program_id, :last_name, :first_name, :mvr_expiration_date, :class_training_date, :canvas_course_complete_date, :meeting_with_admin_date)
+      params.require(:student).permit(:uniqname, :program_id, :registered, :last_name, :first_name, :mvr_expiration_date, :class_training_date, :canvas_course_complete_date, :meeting_with_admin_date)
     end
 
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -14,6 +14,7 @@
 #  updated_at                  :datetime         not null
 #  mvr_status                  :string
 #  program_id                  :bigint
+#  registered                  :boolean          default(TRUE)
 #
 class Student < ApplicationRecord
   belongs_to :program
@@ -22,6 +23,8 @@ class Student < ApplicationRecord
   has_many :notes, as: :noteable
 
   validates :uniqname, uniqueness: { scope: :program, message: "is already in the program list" }
+
+  scope :registered, -> { where(registered: true) }
 
   def driver_past
     Reservation.where('driver_id = ? AND start_time <= ?', self, DateTime.now)

--- a/app/views/programs/students/_form.html.erb
+++ b/app/views/programs/students/_form.html.erb
@@ -16,6 +16,7 @@
         <%= form.text_field :uniqname, required: true, class: "input_text_field" %>
       </div>
       <%= form.hidden_field :program_id, value: @student_program.id %>
+      <%= form.hidden_field :registered, value: false %>
       <div>
         <%= form.submit 'Add Student', class: "secondary_blue_button" %>
       </div>

--- a/app/views/programs/students/_student_list.html.erb
+++ b/app/views/programs/students/_student_list.html.erb
@@ -5,6 +5,7 @@
         <tr>
           <th class="header_th">  </th>
           <th class="header_th">  </th>
+          <th class="header_th">Registered</th>
           <th class="header_th">Uniqname</th>
           <th class="header_th">Last Name</th>
           <th class="header_th">First Name</th>
@@ -21,6 +22,11 @@
             </td>
             <td class="mi_tbody_td">
               <%= link_to 'Edit', edit_program_student_path(@student_program, student), class: "link_to" %>
+            </td>
+            <td class="mi_tbody_td">
+              <% if student.registered %>
+                <i class="fa-solid fa-check"></i>
+              <% end %>
             </td>
             <td class="mi_tbody_td">
               <%= student.uniqname %>

--- a/app/views/programs/students/_student_list_manual.html.erb
+++ b/app/views/programs/students/_student_list_manual.html.erb
@@ -4,6 +4,7 @@
       <thead class="mi_thead">
         <tr>
           <th class="header_th">  </th>
+          <th class="header_th">Registered</th>
           <th class="header_th">Uniqname</th>
           <th class="header_th">Last name</th>
           <th class="header_th">First name</th>
@@ -13,7 +14,12 @@
         <% @students.each do |student| %>
           <tr class="mi_tbody_tr">
             <td class="mi_tbody_td">
-              <%= link_to "Remove", program_student_path(@student_program, student), data: { turbo_confirm: 'Are you sure?', turbo_method: :delete }, class: "link_to" %>
+              <%= link_to "Remove", program_student_path(@student_program, student), data: { turbo_confirm: 'Are you sure?', turbo_method: :delete }, class: "link_to" unless student.registered %>
+            </td>
+            <td class="mi_tbody_td">
+              <% if student.registered %>
+                <i class="fa-solid fa-check"></i>
+              <% end %>
             </td>
             <td class="mi_tbody_td">
               <%= student.uniqname %>

--- a/app/views/programs/students/index.html.erb
+++ b/app/views/programs/students/index.html.erb
@@ -7,9 +7,10 @@
       <div class="my-2">
         <% if policy(Student).update_student_list? %>
           <% if @student_program.not_course %>
-            <%= link_to 'Update Student List', add_students_path(@student_program), class: "secondary_blue_button" %>
+            <%= link_to 'Add Students', add_students_path(@student_program), class: "secondary_blue_button" %>
           <% else %>
             <%= link_to 'Update Student List', update_student_list_path(@student_program), class: "secondary_blue_button" %>
+            <%= link_to 'Add Students', add_students_path(@student_program), class: "secondary_blue_button" %>
           <% end %>
         <% end %>
       </div>

--- a/db/migrate/20230707031632_add_registered_to_student.rb
+++ b/db/migrate/20230707031632_add_registered_to_student.rb
@@ -1,0 +1,5 @@
+class AddRegisteredToStudent < ActiveRecord::Migration[7.0]
+  def change
+    add_column :students, :registered, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_125313) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_07_031632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -229,6 +229,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_125313) do
     t.string "mvr_status"
     t.bigint "program_id"
     t.date "meeting_with_admin_date"
+    t.boolean "registered", default: true
     t.index ["program_id"], name: "index_students_on_program_id"
   end
 


### PR DESCRIPTION
To add unregistered (in Wolverine Access or MPathways) students to a program with course data I added the 'registered' field to the student's table (boolean, default - true).

If a program is not a course all students are added manually with registered = false.
The field is added to students' pages to separate registered and nonregistered students.

The button 'Add Students' is added to the student list for programs that have course data. These lists have two buttons - to update the list by API and manually.

A scope for registered students is created.
