### PR TITLE
Fix create unit preferences when a unit is created and fix delete unit

### DIFF
--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -61,7 +61,7 @@ class UnitsController < ApplicationController
   # DELETE /units/1 or /units/1.json
   def destroy
     if @unit.programs.present? || @unit.cars.present?
-      flash.now[:alert] = "he Unit can't be deleted because it has programs or cars."
+      flash.now[:alert] = "The Unit can't be deleted because it has programs or cars."
       @units = Unit.all
       return
     else

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -25,11 +25,18 @@ class UnitsController < ApplicationController
     authorize @unit
     if @unit.save
       # create preferences for the unit
-      prefs = UnitPreference.distinct.pluck(:name, :description)
-      prefs.each do |name, descr|
-        unless UnitPreference.create(name: name, description: descr, unit_id: @unit.id)
-          @units = Unit.all
-          return
+      prefs = UnitPreference.distinct.pluck(:name, :description, :pref_type)
+      prefs.each do |name, descr, type|
+        if type == "boolean"
+          unless UnitPreference.create(name: name, description: descr, type: type, on_off: false, unit_id: @unit.id)
+            @units = Unit.all
+            return
+          end
+        else
+          unless UnitPreference.create(name: name, description: descr, type: type, unit_id: @unit.id)
+            @units = Unit.all
+            return
+          end 
         end
       end
       @unit = Unit.new

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -26,14 +26,14 @@ class UnitsController < ApplicationController
     if @unit.save
       # create preferences for the unit
       prefs = UnitPreference.distinct.pluck(:name, :description, :pref_type)
-      prefs.each do |name, descr, type|
-        if type == "boolean"
-          unless UnitPreference.create(name: name, description: descr, type: type, on_off: false, unit_id: @unit.id)
+      prefs.each do |name, descr, pref_type|
+        if pref_type == "boolean"
+          unless UnitPreference.create(name: name, description: descr, pref_type: pref_type, on_off: false, unit_id: @unit.id)
             @units = Unit.all
             return
           end
         else
-          unless UnitPreference.create(name: name, description: descr, type: type, unit_id: @unit.id)
+          unless UnitPreference.create(name: name, description: descr, pref_type: pref_type, unit_id: @unit.id)
             @units = Unit.all
             return
           end 
@@ -60,8 +60,17 @@ class UnitsController < ApplicationController
 
   # DELETE /units/1 or /units/1.json
   def destroy
-    if @unit.destroy
-      flash.now[:notice] = "Unit was deleted."
+    if @unit.programs.present? || @unit.cars.present?
+      flash.now[:alert] = "he Unit can't be deleted because it has programs or cars."
+      @units = Unit.all
+      return
+    else
+      if @unit.destroy
+        flash.now[:notice] = "Unit was deleted."
+      else
+        @units = Unit.all
+        render :aindex, status: :unprocessable_entity
+      end
     end
     @units = Unit.all
   end


### PR DESCRIPTION
The unit preferences table was changed (new fields added), and therefore creating unit preferences in the create a new unit method stooped working correctly. The pull request addresses the issue.
Also, now before deleting a unit the Unit controller checks if the unit has programs and cars associated with it.