### PR TITLE
Lra 672 lsa ride share add minimum number of hours before reservation to preferences

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -64,14 +64,14 @@ class ReservationsController < ApplicationController
       @term_id = @program.term.id
       @sites = @program.sites
       @cars = @cars.where(unit_id: @unit_id).order(:car_number)
-      @min_date = default_reservation_for_students
+      @min_date = default_reservation_for_students(@unit_id)
     elsif is_manager?(current_user)
       @program = Program.find(params[:program_id])
       @unit_id = @program.unit_id
       @term_id = @program.term.id
       @sites = @program.sites
       @cars = @cars.where(unit_id: @unit_id).order(:car_number)
-      @min_date = default_reservation_for_students
+      @min_date = default_reservation_for_students(@unit_id)
     elsif params[:unit_id].present?
       @unit_id = params[:unit_id]
       @min_date =  DateTime.now
@@ -82,7 +82,7 @@ class ReservationsController < ApplicationController
     if params[:day_start].present?
       @day_start = params[:day_start].to_date
     else
-      @day_start = default_reservation_for_students
+      @day_start = default_reservation_for_students(@unit_id)
     end
     if params[:term_id].present?
       @term_id = params[:term_id]

--- a/app/controllers/unit_preferences_controller.rb
+++ b/app/controllers/unit_preferences_controller.rb
@@ -30,6 +30,9 @@ class UnitPreferencesController < ApplicationController
           if pref.pref_type == 'time' || pref.pref_type == 'string'
             pref.update(value: v)
           end
+          if pref.pref_type == 'integer'
+            pref.update(value: v.to_s)
+          end
         end
       end
     end

--- a/app/models/unit_preference.rb
+++ b/app/models/unit_preference.rb
@@ -16,7 +16,7 @@
 class UnitPreference < ApplicationRecord
   belongs_to :unit
 
-  enum :pref_type, [:boolean, :string, :time], prefix: true, scopes: true
+  enum :pref_type, [:boolean, :integer, :string, :time], prefix: true, scopes: true
 
   validates :name, uniqueness: { scope: :unit_id, message: "should be unique." }
   validates_presence_of :pref_type, :description

--- a/app/views/unit_preferences/unit_prefs.html.erb
+++ b/app/views/unit_preferences/unit_prefs.html.erb
@@ -14,6 +14,9 @@
               <% elsif pref.pref_type == "string" %>
                 <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="fancy_label"><%= pref.description %></label>
                 <%= text_field_tag("unit_prefs[#{unit.id}][#{pref.name}]", pref.value, {class: "input_text_field"}) %>
+              <% elsif pref.pref_type == "integer" %>
+                <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="fancy_label"><%= pref.description %></label>
+                <%= number_field_tag("unit_prefs[#{unit.id}][#{pref.name}]", pref.value, {class: "input_text_field"}) %>
               <% elsif pref.pref_type == "time" %>
                 <label for=<%= "unit_prefs[#{unit.id}][#{pref.name}]" %> class="fancy_label"><%= pref.description %> *</label>
                 <%#= text_field_tag("unit_prefs[#{unit.id}][#{pref.name}]", pref.value, {required: true, class: "input_text_field"}) %>


### PR DESCRIPTION
Psychology requires a minimum of 72 hours before students can make reservations. CEAL Ride allows 48 hours.

Therefore let’s move this number to Units' preferences.

- Add 'integer' prefs_type
- Create a Unit preference "hours_before_reservation" - The minimum number of hours before students can make reservations.
- Use that preference value instead of hard coded 72 hours.

