### PR TITLE
LRA-664-lsa-ride-share-conflict-between-registered-and-manually-added-students

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -24,6 +24,7 @@ class Student < ApplicationRecord
   validates :uniqname, uniqueness: { scope: :program, message: "is already in the program list" }
 
   scope :registered, -> { where(registered: true) }
+  scope :added_manually, -> { where(registered: false) }
 
   def driver_past
     Reservation.where('driver_id = ? AND start_time <= ?', self, DateTime.now)


### PR DESCRIPTION
If the update_students method (using class_roster_operational API) finds that a registered student has already been added to the program manually, the API will update the student record to registered = true. The manually added student becomes registered.