### PR TITLE
error message shows if value less than 50% fuel

### DIFF
--- a/app/views/vehicle_reports/_vehicle_report.html.erb
+++ b/app/views/vehicle_reports/_vehicle_report.html.erb
@@ -21,7 +21,7 @@
     <%= render 'student_status', vehicle_report: vehicle_report %>
 
     <% if vehicle_report.gas_end.present?  %>
-      <% if vehicle_report.gas_end <= 50 %>
+      <% if vehicle_report.gas_end < 50 %>
         <div class="error_text" data-vehiclereport-target="gas_error">
           <span>The fuel level should be at least 50%. Please refuel.</span>
         </div>


### PR DESCRIPTION
Vehicle report error message "The fuel level should be at least 50%. Please refuel." now only shows if fuel return is less than 50%. Previously, selecting 50% for fuel return would show this error message, which is not correct.