### PR TITLE
Lra 744 lsa ride share update code to use ldap lookup gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'letter_opener_web'
 # Use OmniAuth gems to implement Shibboleth SAML authentication
 gem 'omniauth-saml', '~> 2.1'
 gem "omniauth-rails_csrf_protection"
-gem 'ldap_lookup', '~> 0.1.6'
+gem 'ldap_lookup', '~> 0.1.8'
 gem 'pundit', '~> 2.3'
 gem 'simple_calendar', '~> 2.4', '>= 2.4.3'
 gem 'requestjs-rails', '~> 0.0.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,8 +182,8 @@ GEM
     jwt (2.7.1)
     launchy (2.5.2)
       addressable (~> 2.8)
-    ldap_lookup (0.1.7)
-      net-ldap (~> 0.17.0)
+    ldap_lookup (0.1.8)
+      net-ldap (~> 0.18.0)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     letter_opener_web (2.0.0)
@@ -211,7 +211,7 @@ GEM
     net-imap (0.3.7)
       date
       net-protocol
-    net-ldap (0.17.1)
+    net-ldap (0.18.0)
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.1)
@@ -411,7 +411,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
-  ldap_lookup (~> 0.1.6)
+  ldap_lookup (~> 0.1.8)
   letter_opener_web
   omniauth-rails_csrf_protection
   omniauth-saml (~> 2.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
         name = LdapLookup.get_simple_name(uniqname)
         result['valid'] =  true
         if name.include?("No displayname")
-          result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manualy."
+          result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manually."
         else
           result['first_name'] = name.split(" ").first
           result['last_name'] = name.split(" ").last

--- a/app/controllers/concerns/student_api.rb
+++ b/app/controllers/concerns/student_api.rb
@@ -172,17 +172,18 @@ module StudentApi
 
   def get_name(uniqname)
     result = {'valid' => false, 'note' => '', 'last_name' => '', 'first_name' => ''}
-    name = LdapLookup.get_simple_name(uniqname)
-    if name == "No such user"
-      result['note'] = "The '#{uniqname}' uniqname is not valid."
-    else
-      result['valid'] =  true
-      if name.nil?
-        result['note'] = "Mcommunity returns no name for '#{uniqname}' uniqname."
+    valid = LdapLookup.uid_exist?(uniqname)
+    if valid
+      result['valid'] = true
+      name = LdapLookup.get_simple_name(uniqname)
+      if name.include?("No displayname")
+        result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname."
       else
         result['first_name'] = name.split(" ").first
         result['last_name'] = name.split(" ").last
       end
+    else
+      result['note'] = "The '#{uniqname}' uniqname is not valid."
     end
     return result
   end

--- a/app/controllers/faculty_surveys_controller.rb
+++ b/app/controllers/faculty_surveys_controller.rb
@@ -51,7 +51,11 @@ class FacultySurveysController < ApplicationController
     end
     if @faculty_survey.save
       add_config_questions(@faculty_survey)
-      redirect_to faculty_survey_config_questions_path(@faculty_survey), notice: "Faculty survey was successfully created." + result['note'] + " You can edit the questions and send an email to the instructor."
+      if result['note'].include?("Mcommunity returns no name")
+        redirect_to edit_faculty_survey_path(@faculty_survey), notice: "Faculty survey was successfully created." + result['note'] + " Add first and last name manually."
+      else
+        redirect_to faculty_survey_config_questions_path(@faculty_survey), notice: "Faculty survey was successfully created." + result['note'] + " You can edit the questions and send an email to the instructor."
+      end
     else
       render :new, status: :unprocessable_entity
     end
@@ -71,7 +75,7 @@ class FacultySurveysController < ApplicationController
       end
     end
     if @faculty_survey.save
-      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully updated."
+      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully updated. Click on Survey Questions to edit questions and send email to instructor."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/faculty_surveys_controller.rb
+++ b/app/controllers/faculty_surveys_controller.rb
@@ -75,7 +75,7 @@ class FacultySurveysController < ApplicationController
       end
     end
     if @faculty_survey.save
-      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully updated. Click on Survey Questions to edit questions and send email to instructor."
+      redirect_to faculty_surveys_path(:term_id => @faculty_survey.term_id), notice: "Faculty survey was successfully updated. Click on Survey Questions to edit the questions and send an email to instructor."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/programs/managers_controller.rb
+++ b/app/controllers/programs/managers_controller.rb
@@ -32,6 +32,7 @@ class Programs::ManagersController < ApplicationController
         end
       else
         flash.now[:alert] = result['note']
+        @manager = Manager.new
         return
       end
     end

--- a/app/controllers/programs/managers_controller.rb
+++ b/app/controllers/programs/managers_controller.rb
@@ -32,7 +32,6 @@ class Programs::ManagersController < ApplicationController
         end
       else
         flash.now[:alert] = result['note']
-        @manager = Manager.new
         return
       end
     end

--- a/app/controllers/programs/students_controller.rb
+++ b/app/controllers/programs/students_controller.rb
@@ -28,7 +28,6 @@ class Programs::StudentsController < ApplicationController
     @student = Student.new(student_params)
     authorize @student
     result = get_name(uniqname)
-    
     if result['valid']
       @student.first_name = result['first_name']
       @student.last_name = result['last_name']
@@ -48,6 +47,7 @@ class Programs::StudentsController < ApplicationController
   def destroy
     if @student.reservations.present?
       flash.now[:alert] = "Student has reservations and can't be removed."
+      @student = Student.new
       @students = @student_program.students.order(registered: :desc).order(:last_name)
       return
     else

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -107,9 +107,7 @@ class ProgramsController < ApplicationController
     else
       @instructor = Manager.new(uniqname: uniqname)
       valid = LdapLookup.uid_exist?(uniqname)
-      name = LdapLookup.get_simple_name(uniqname)
       if valid
-        result['valid'] =  true
         # check if uniqname is an admin uniqname
         ldap_group = is_member_of_admin_groups?(uniqname)
         if ldap_group
@@ -117,6 +115,8 @@ class ProgramsController < ApplicationController
           result['note'] = "#{uniqname} is an admin - a member of #{ldap_group} group. Admins can't be instructors."
           return result
         end
+        name = LdapLookup.get_simple_name(uniqname)
+        result['valid'] =  true
         if name.include?("No displayname")
           result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manualy."
           @instructor.first_name = ''

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -118,7 +118,7 @@ class ProgramsController < ApplicationController
         name = LdapLookup.get_simple_name(uniqname)
         result['valid'] =  true
         if name.include?("No displayname")
-          result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manualy."
+          result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manually."
           @instructor.first_name = ''
           @instructor.last_name = ''
         else

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -106,10 +106,9 @@ class ProgramsController < ApplicationController
       result['instructor_id'] = Manager.find_by(uniqname: uniqname).id
     else
       @instructor = Manager.new(uniqname: uniqname)
+      valid = LdapLookup.uid_exist?(uniqname)
       name = LdapLookup.get_simple_name(uniqname)
-      if name == "No such user"
-        result['note'] = "The '#{uniqname}' uniqname is not valid."
-      else
+      if valid
         result['valid'] =  true
         # check if uniqname is an admin uniqname
         ldap_group = is_member_of_admin_groups?(uniqname)
@@ -118,8 +117,8 @@ class ProgramsController < ApplicationController
           result['note'] = "#{uniqname} is an admin - a member of #{ldap_group} group. Admins can't be instructors."
           return result
         end
-        if name.nil?
-          result['note'] = "Mcommunity returns no name for '#{uniqname}' uniqname."
+        if name.include?("No displayname")
+          result['note'] = " Mcommunity returns no name for '#{uniqname}' uniqname. Please go to Programs->Managers and add first and last names manualy."
           @instructor.first_name = ''
           @instructor.last_name = ''
         else
@@ -130,8 +129,10 @@ class ProgramsController < ApplicationController
           result['instructor_id'] = @instructor.id
         else 
           result['valid'] =  false
-          result['note'] = 'Error saving instructor record. Please report the issue'
+          result['note'] = 'Error saving instructor record. Please report the issue.'
         end
+      else
+        result['note'] = "The '#{uniqname}' uniqname is not valid."
       end
     end
     return result

--- a/app/views/managers/_form.html.erb
+++ b/app/views/managers/_form.html.erb
@@ -12,21 +12,31 @@
   <% end %>
 
   <div class="my-5">
-      <%= form.label :canvas_course_complete_date, class: "fancy_label" %>
-      <%= form.date_field :canvas_course_complete_date, class: "input_text_field" %>
-    </div>
+    <%= form.label :first_name, class: "fancy_label" %>
+    <%= form.text_field :first_name, class: "input_text_field" %>
+  </div>
 
-    <div class="my-5">
-      <%= form.label :meeting_with_admin_date, "In Person Orientation Date:", class: "fancy_label" %>
-      <%= form.date_field :meeting_with_admin_date, class: "input_text_field" %>
-    </div>
+  <div class="my-5">
+    <%= form.label :last_name, class: "fancy_label" %>
+    <%= form.text_field :last_name, class: "input_text_field" %>
+  </div>
 
-    <div class="inline">
-      <%= form.submit class: "secondary_blue_button" %>
-    </div>
-    <%= link_to managers_path(@manager) do %>
-      <span class="tertiary_button">Cancel
-        <i class="fa fa-times" aria-hidden="true"></i>
-      </span>
-    <% end %>
+  <div class="my-5">
+    <%= form.label :canvas_course_complete_date, class: "fancy_label" %>
+    <%= form.date_field :canvas_course_complete_date, class: "input_text_field" %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :meeting_with_admin_date, "In Person Orientation Date:", class: "fancy_label" %>
+    <%= form.date_field :meeting_with_admin_date, class: "input_text_field" %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "secondary_blue_button" %>
+  </div>
+  <%= link_to managers_path(@manager) do %>
+    <span class="tertiary_button">Cancel
+      <i class="fa fa-times" aria-hidden="true"></i>
+    </span>
+  <% end %>
 <% end %>

--- a/app/views/managers/edit.html.erb
+++ b/app/views/managers/edit.html.erb
@@ -1,4 +1,7 @@
 <h1>Edit Manager</h1>
+<p class="body-sm-bold-text mt-2">
+    Uniqname: <%= @manager.uniqname %>
+  </p>
 
 <%= turbo_frame_tag 'edit_manager' do %>
   <%= render 'form' %>


### PR DESCRIPTION
Run bundle before testing the code.

Update the code using the new version of the ldap_lookup gem.
LdapLookup methods are used for:
- is a uniqname valid: LdapLookup.uid_exist?(uniqname)
- is a uniqname private and has no displayname: LdapLookup.get_simple_name(uniqname)
- get the last name and first name for the uniqname: LdapLookup.get_simple_name(uniqname)
- is a uniqname a member of admins' Ldap groups: LdapLookup.is_member_of_group?(uniqname, group)

The gem is used in these cases:
- create or edit a program - when an instructor name is added/edited
  - check if a uniqname exists in the managers table - use that id to add an instructor to the program
  - check that the uniqname is not an admin's uniqname; admins can't be instructors
- add managers to a program; when a new uniqname is added
  - check that the uniqname is not the program's instructor
  - check that the uniqname is not an admin's uniqname; admins can't be instructors
- when students are added to a program manually
- create a program survey - when an instructor's uniqname is added