### PR TITLE
LRa-747 LSA RideShare - students and managers interface - add current reservations

### DIFF
--- a/app/controllers/welcome_pages_controller.rb
+++ b/app/controllers/welcome_pages_controller.rb
@@ -61,7 +61,7 @@ class WelcomePagesController < ApplicationController
     @contact_data = UnitPreference.select(:unit_id, :name, :value).where(unit_id: unit_ids).where("name = 'unit_office' OR name = 'contact_phone'").group_by(&:unit_id).to_a
     if @program.present?
       update_status(@manager, @program)
-      @reservations_current = @manager.reservations_current.sort_by(&:start_time)
+      @reservations_current = @manager.reservations_current.where(program_id: @program.id).sort_by(&:start_time)
       @reservations_past = @manager.reservations_past.where(program_id: @program.id).sort_by(&:start_time).reverse
       @reservations_future = @manager.reservations_future.where(program_id: @program.id).sort_by(&:start_time)
       unit_ids = [@program.unit_id]

--- a/app/controllers/welcome_pages_controller.rb
+++ b/app/controllers/welcome_pages_controller.rb
@@ -18,6 +18,7 @@ class WelcomePagesController < ApplicationController
     end
     if @student.present?
       update_status(@student, @student.program)
+      @reservations_current = @student.reservations_current.sort_by(&:start_time)
       @reservations_past = @student.reservations_past.sort_by(&:start_time).reverse
       @reservations_future = @student.reservations_future.sort_by(&:start_time)
       unit_ids = [@program.unit_id]
@@ -60,6 +61,7 @@ class WelcomePagesController < ApplicationController
     @contact_data = UnitPreference.select(:unit_id, :name, :value).where(unit_id: unit_ids).where("name = 'unit_office' OR name = 'contact_phone'").group_by(&:unit_id).to_a
     if @program.present?
       update_status(@manager, @program)
+      @reservations_current = @manager.reservations_current.sort_by(&:start_time)
       @reservations_past = @manager.reservations_past.where(program_id: @program.id).sort_by(&:start_time).reverse
       @reservations_future = @manager.reservations_future.where(program_id: @program.id).sort_by(&:start_time)
       unit_ids = [@program.unit_id]

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -58,15 +58,15 @@ class Manager < ApplicationRecord
 
   def reservations_current
     Reservation.current_term.where(reserved_by: User.find_by(uniqname: self.uniqname)).where("(start_time BETWEEN ? AND ?) OR (start_time < ? AND end_time > ?)",
-    Date.today.beginning_of_day, Date.today.end_of_day, Date.today.beginning_of_day, Date.today.beginning_of_day)
+    Date.today.beginning_of_day, Date.today.end_of_day, Date.today.end_of_day, Date.today.beginning_of_day)
   end
 
   def reservations_past
-    Reservation.current_term.where('reserved_by = ? AND end_time <= ?', User.find_by(uniqname: self.uniqname), DateTime.now)
+    Reservation.current_term.where('reserved_by = ? AND end_time < ?', User.find_by(uniqname: self.uniqname), Date.beginning_of_day)
   end
 
   def reservations_future
-    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), DateTime.now)
+    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), Date.end_of_day)
   end
 
   def display_name

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -56,12 +56,17 @@ class Manager < ApplicationRecord
     where.not(class_training_date: nil) 
   end
 
+  def reservations_current
+    Reservation.current_term.where(reserved_by: User.find_by(uniqname: self.uniqname)).where("(start_time BETWEEN ? AND ?) OR (start_time < ? AND end_time > ?)",
+    Date.today.beginning_of_day, Date.today.end_of_day, Date.today.beginning_of_day, Date.today.beginning_of_day)
+  end
+
   def reservations_past
-    Reservation.where('reserved_by = ? AND start_time <= ?', User.find_by(uniqname: self.uniqname), DateTime.now)
+    Reservation.current_term.where('reserved_by = ? AND end_time <= ?', User.find_by(uniqname: self.uniqname), DateTime.now)
   end
 
   def reservations_future
-    Reservation.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), DateTime.now)
+    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), DateTime.now)
   end
 
   def display_name

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -62,11 +62,11 @@ class Manager < ApplicationRecord
   end
 
   def reservations_past
-    Reservation.current_term.where('reserved_by = ? AND end_time < ?', User.find_by(uniqname: self.uniqname), Date.beginning_of_day)
+    Reservation.current_term.where('reserved_by = ? AND end_time < ?', User.find_by(uniqname: self.uniqname), Date.today.beginning_of_day)
   end
 
   def reservations_future
-    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), Date.end_of_day)
+    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), Date.today.end_of_day)
   end
 
   def display_name

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -60,9 +60,9 @@ class Reservation < ApplicationRecord
   scope :include_vehicle_reports, -> { Reservation.includes(:vehicle_report) }
   scope :current_term, -> { include_vehicle_reports.where(program_id: Program.current_term.ids)}
   scope :current_past, -> { current_term.where("(end_time < ?) OR (start_time < ? AND end_time > ?)",
-    Date.today.end_of_day, Date.today.beginning_of_day, Date.today.beginning_of_day) }
+    Date.today.end_of_day, Date.today.end_of_day, Date.today.beginning_of_day) }
   scope :with_no_vehicle_reports, -> { current_past.where(vehicle_report: {id: nil}) }
-  scope :with_not_complete_vehicle_reports, -> { current_past.where.not(vehicle_report: {id: nil}).where(vehicle_report: {student_status: false}) }
+  scope :with_not_complete_vehicle_reports, -> { current_past.where(vehicle_report: {student_status: false}) }
   scope :no_or_not_complete_vehicle_reports, -> { Reservation.with_not_complete_vehicle_reports.or(Reservation.with_no_vehicle_reports) }
   scope :complete_vehicle_reports, -> { current_term.where(vehicle_report: {student_status: true}) }
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -57,6 +57,14 @@ class Reservation < ApplicationRecord
   validate :approve_requires_car, on: :update
 
   scope :with_passengers, -> { Reservation.includes(:passengers) }
+  scope :include_vehicle_reports, -> { Reservation.includes(:vehicle_report) }
+  scope :current_term, -> { include_vehicle_reports.where(program_id: Program.current_term.ids)}
+  scope :current_past, -> { current_term.where("(end_time < ?) OR (start_time < ? AND end_time > ?)",
+    Date.today.end_of_day, Date.today.beginning_of_day, Date.today.beginning_of_day) }
+  scope :with_no_vehicle_reports, -> { current_past.where(vehicle_report: {id: nil}) }
+  scope :with_not_complete_vehicle_reports, -> { current_past.where.not(vehicle_report: {id: nil}).where(vehicle_report: {student_status: false}) }
+  scope :no_or_not_complete_vehicle_reports, -> { Reservation.with_not_complete_vehicle_reports.or(Reservation.with_no_vehicle_reports) }
+  scope :complete_vehicle_reports, -> { current_term.where(vehicle_report: {student_status: true}) }
 
   def reservation_date
     start_d = start_time.present? ? start_time.strftime("%m/%d/%Y %I:%M%p") : ''

--- a/app/views/welcome_pages/_manager_reservations_current.html.erb
+++ b/app/views/welcome_pages/_manager_reservations_current.html.erb
@@ -1,0 +1,97 @@
+<%= turbo_frame_tag 'manager_reservations' do %>
+  <h3 class="my-2">Current Reservations</h3>
+  <div class="min-w-full">
+    <table class="mi_table" id="desk-table">
+      <thead class="border border-l-0 border-r-0 border-gray-um60">
+        <tr>
+          <th class="header_th">Reservation</th>
+          <th class="header_th">Approved</th>
+          <th class="header_th">Pick-up</th>
+          <th class="header_th">Drop-off</th>
+          <th class="header_th">Site</th>
+          <th class="header_th">Car</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @reservations_current.each do |reservation| %>
+          <tr>
+            <% if reservation.driver_manager == @manager %>
+              <td class="mi_tbody_td">
+                <%= link_to 'Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% else %>
+              <td class="mi_tbody_td">
+                <%= link_to 'Reserved By', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% end %>
+            <td class="mi_tbody_td">
+              <% if reservation.approved %>
+                <i class="fa-solid fa-check"></i>
+              <% end %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_date_time(reservation.start_time + 15.minute) %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_date_time(reservation.end_time - 15.minute) %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= reservation.site.title %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_car(reservation) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <table id="phone-table">
+      <% @reservations_current.each do |reservation| %>
+        <tr class="mi_tbody_tr">
+        <th class="header_mobile">Reservation</th>
+          <% if reservation.driver_manager == @manager %>
+            <td class="mi_tbody_td">
+              <%= link_to 'Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+            </td>
+          <% else %>
+            <td class="mi_tbody_td">
+              <%= link_to 'Reserved By', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+            </td>
+          <% end %>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Approved</th>
+          <td class="mi_tbody_td">
+            <% if reservation.approved %>
+              <i class="fa-solid fa-check"></i>
+            <% end %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Pick-up</th>
+          <td class="mi_tbody_td">
+            <%= show_date_time(reservation.start_time + 15.minute) %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Drop-off</th>
+          <td class="mi_tbody_td">
+            <%= show_date_time(reservation.end_time - 15.minute) %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Site</th>
+          <td class="mi_tbody_td">
+            <%= reservation.site.title %>
+          </td>
+        </tr>
+        <tr class="mobile_tr">
+          <th class="header_mobile">Car</th>
+          <td class="mi_tbody_td">
+            <%= show_car(reservation) %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>

--- a/app/views/welcome_pages/_student_reservations_current.html.erb
+++ b/app/views/welcome_pages/_student_reservations_current.html.erb
@@ -1,0 +1,135 @@
+<%= turbo_frame_tag 'student_reservations' do %>
+  <h3 class="my-2">Current Reservations</h3>
+  <div class="min-w-full">
+    <table class="mi_table" id="desk-table">
+      <thead class="border border-l-0 border-r-0 border-gray-um60">
+        <tr>
+          <th class="header_th">Reservation</th>
+          <th class="header_th">Approved</th>
+          <th class="header_th">Pick-up</th>
+          <th class="header_th">Drop-off</th>
+          <th class="header_th">Site</th>
+          <th class="header_th">Car</th>
+          <th class="header_th">Vehicle Report</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @reservations_current.each do |reservation| %>
+          <tr>
+            <% if reservation.driver == @student %>
+              <td class="mi_tbody_td">
+                <%= link_to 'Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% elsif reservation.backup_driver == @student %>
+              <td class="mi_tbody_td">
+                <%= link_to 'Backup Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% else %>
+              <td class="mi_tbody_td">
+                <%= link_to 'Passenger', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% end %>
+            <td class="mi_tbody_td">
+              <% if reservation.approved %>
+                <i class="fa-solid fa-check"></i>
+              <% end %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_date_time(reservation.start_time + 15.minute) %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_date_time(reservation.end_time - 15.minute) %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= reservation.site.title %>
+            </td>
+            <td class="mi_tbody_td">
+              <%= show_car(reservation) %>
+            </td>
+            <td class="mi_tbody_td">
+              <% if reservation.vehicle_report.present? %>
+                <% if reservation.vehicle_report.approved %>
+                  Approved by admin
+                <% elsif reservation.vehicle_report.student_status %>
+                  Completed
+                <% else %>
+                  <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} %>
+                <% end %>
+              <% else %>
+                <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.car.present? %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <table id="phone-table">
+      <% @reservations_current.each do |reservation| %>
+        <tr class="mi_tbody_tr">
+        <th class="header_mobile">Reservation</th>
+          <% if reservation.driver == @student %>
+            <td class="mi_tbody_td">
+              <%= link_to 'Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+            </td>
+          <% elsif reservation.backup_driver == @student %>
+            <td class="mi_tbody_td">
+              <%= link_to 'Backup Driver', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+            </td>
+          <% else %>
+            <td class="mi_tbody_td">
+              <%= link_to 'Passenger', reservation_path(reservation), class: "link_to", data: {turbo_frame: "_top"} %>
+            </td>
+          <% end %>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Approved</th>
+          <td class="mi_tbody_td">
+            <% if reservation.approved %>
+              <i class="fa-solid fa-check"></i>
+            <% end %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Pick-up</th>
+          <td class="mi_tbody_td">
+            <%= show_date_time(reservation.start_time + 15.minute) %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Drop-off</th>
+          <td class="mi_tbody_td">
+            <%= show_date_time(reservation.end_time - 15.minute) %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Site</th>
+          <td class="mi_tbody_td">
+            <%= reservation.site.title %>
+          </td>
+        </tr>
+        <tr class="mi_tbody_tr">
+          <th class="header_mobile">Car</th>
+          <td class="mi_tbody_td">
+            <%= show_car(reservation) %>
+          </td>
+        </tr>
+        <tr class="mobile_tr">
+          <th class="header_mobile">Vehicle Report</th>
+          <td class="mi_tbody_td">
+            <% if reservation.vehicle_report.present? %>
+              <% if reservation.vehicle_report.approved %>
+                Approved by admin
+              <% elsif reservation.vehicle_report.student_status %>
+                Completed
+              <% else %>
+                <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} %>
+              <% end %>
+            <% else %>
+              <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.car.present? %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>

--- a/app/views/welcome_pages/manager.html.erb
+++ b/app/views/welcome_pages/manager.html.erb
@@ -39,6 +39,11 @@
           <p class="body-md-text"><%= show_manager(@program, current_user) %></p>
         <% end %>
         <div>
+          <% if @reservations_current.present? %>
+            <%= render 'manager_reservations_current' %>
+          <% end %>
+        </div>
+        <div>
           <% if @reservations_future.present? %>
             <%= render 'manager_reservations_future' %>
           <% end %>

--- a/app/views/welcome_pages/student.html.erb
+++ b/app/views/welcome_pages/student.html.erb
@@ -41,6 +41,11 @@
           <h2><%= @program.display_name_with_title_and_unit %></h2>
         <% end %>
         <div>
+          <% if @reservations_current.present? %>
+            <%= render 'student_reservations_current' %>
+          <% end %>
+        </div>
+        <div>
           <% if @reservations_future.present? %>
             <%= render 'student_reservations_future' %>
           <% end %>


### PR DESCRIPTION
Students have a hard time finding on their phones vehicle reports that they have to fill out.
It happens because these vehicle reports links are in the Past Reservations part which is at the bottom of the students page.

Solution. 

- Create a Student Current Reservations list which includes reservations that started but have not ended yet and reservations that ended but have no vehicle reports or have not complete vehicle reports.
- Create Managers Current Reservations list which includes reservations that started but have not ended yet
  - Managers don’t care about vehicle reports.
- The Student's Past Reservations section should include only reservations with complete vehicle reports.
- The managers' Past Reservations section should include reservations that have ended already.
- Display only current term reservations on students' and managers' pages.