### PR TITLE
clicking "today" returns to current week

### DIFF
--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -8,7 +8,7 @@
     <% end %>
     <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
 
-    <%= link_to 'Today', week_calendar_path, class: "secondary_yellow_button" %>
+    <%= link_to 'Today', week_calendar_path(:unit_id => @unit_id), class: "secondary_yellow_button" %>
   </div>
 
   <table class="table-fixed">


### PR DESCRIPTION
Fixed unit needed error, Today button in weekly view now works and returns to current week