### PR TITLE
LRA-775 Edit change add/edit drivers workflow

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,7 +1,7 @@
 class ReservationsController < ApplicationController
   before_action :auth_user
   before_action :set_reservation, only: %i[ show edit update destroy add_drivers add_passengers remove_passenger 
-    finish_reservation update_passengers send_reservation_updated_email cancel_recurring_reservation add_drivers_later approve_all_recurring edit_long ]
+    finish_reservation update_passengers send_reservation_updated_email cancel_recurring_reservation add_drivers_later approve_all_recurring edit_long add_edit_drivers]
   before_action :set_terms_and_units
   before_action :set_programs
   before_action :set_cars, only: %i[ new new_long get_available_cars get_available_cars_long ]
@@ -279,24 +279,6 @@ class ReservationsController < ApplicationController
         return
       end
     end
-    if params[:reservation][:driver_id].present? || params[:reservation][:driver_manager_id].present?
-      if @reservation.driver_manager.present? && params[:reservation][:driver_id].present?
-        @reservation.update(driver_manager: nil)
-      end
-      if @reservation.update(reservation_params)
-        if params[:edit] == "true"
-          redirect_to reservation_path(@reservation), notice: "Drivers were updated."
-          return
-        else
-          redirect_to add_passengers_path(@reservation)
-         return
-        end
-      else
-        @drivers = @reservation.program.students.eligible_drivers
-        render :add_drivers, status: :unprocessable_entity
-        return
-      end
-    end
 
     @reservation.attributes = reservation_params
     @reservation.car_id = params[:car_id]
@@ -321,6 +303,38 @@ class ReservationsController < ApplicationController
         @students = Student.all
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @reservation.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def add_edit_drivers
+    if params[:reservation][:driver_id].present? || params[:reservation][:driver_manager_id].present?
+      drivers_emails = reservation_drivers_emails
+      if @reservation.driver_manager.present? && params[:reservation][:driver_id].present?
+        @reservation.update(driver_manager: nil)
+      end
+      if @reservation.update(reservation_params)
+        if params[:edit] == "true"
+          @reservation = Reservation.find(params[:id])
+          drivers_emails_new = reservation_drivers_emails
+          if drivers_emails == drivers_emails_new
+            notice = "Drivers were not changed"
+          else
+            drivers_emails << drivers_emails_new
+            drivers_emails = drivers_emails.flatten.uniq
+            ReservationMailer.car_reservation_drivers_edited(@reservation, drivers_emails, current_user).deliver_now
+            notice = "Drivers were updated."
+          end
+          redirect_to reservation_path(@reservation), notice: notice
+          return
+        else
+          redirect_to add_passengers_path(@reservation)
+         return
+        end
+      else
+        @drivers = @reservation.program.students.eligible_drivers
+        render :add_drivers, status: :unprocessable_entity
+        return
       end
     end
   end
@@ -496,6 +510,20 @@ class ReservationsController < ApplicationController
       @cars = @cars.where(unit_id: @unit_id).order(:car_number)
       @min_date = default_reservation_for_students(@unit_id)
       @max_date = max_day_for_reservation(program)
+    end
+
+    def reservation_drivers_emails
+      drivers_emails = []
+      if @reservation.driver.present?
+        drivers_emails << email_address(@reservation.driver)
+      end
+      if @reservation.backup_driver.present?
+        drivers_emails << email_address(@reservation.backup_driver)
+      end
+      if @reservation.driver_manager.present?
+        drivers_emails << email_address(@reservation.driver_manager)
+      end
+      return drivers_emails
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/javascript/controllers/driver_controller.js
+++ b/app/javascript/controllers/driver_controller.js
@@ -106,9 +106,9 @@ export default class extends Controller {
     if(submitForm == false) {
       event.preventDefault()
     }
-    else {
-      Turbo.navigator.submitForm(this.formTarget)
-    }
+    // else {
+    //   Turbo.navigator.submitForm(this.formTarget)
+    // }
   }
 
 }

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -77,15 +77,12 @@ class ReservationMailer < ApplicationMailer
       sent_to: @recipients, sent_by: user.id, sent_at: DateTime.now)
   end
 
-  def car_reservation_drivers_edited(drivers_reservation, drivers_emails, reserved_by)
+  def car_reservation_drivers_edited(drivers_reservation, drivers_emails, user)
     @reservation = drivers_reservation
     @unit_email_message = get_unit_email_message(@reservation)
     set_reservation_data(@reservation)
     recipients = drivers_emails
-    recipients << User.find(reserved_by).principal_name.presence
-    recipients << email_address(@reservation.driver) if @reservation.driver.present?
-    recipients << email_address(@reservation.driver_manager) if @reservation.driver_manager.present?
-    recipients << email_address(@reservation.backup_driver) if @reservation.backup_driver.present?
+    recipients << User.find(@reservation.reserved_by).principal_name.presence
     set_passengers
     set_driver_name
     recipients << @passengers_emails if @passengers_emails.present?
@@ -93,7 +90,7 @@ class ReservationMailer < ApplicationMailer
     @recipients = recipients.uniq.join(", ")
     mail(to: @recipients, subject: "Reservation drivers changed for program: #{@reservation.program.display_name}" )
     EmailLog.create(sent_from_model: "Reservation", record_id: @reservation.id, email_type: "drivers_edited",
-      sent_to: @recipients, sent_by: reserved_by, sent_at: DateTime.now)
+      sent_to: @recipients, sent_by: user.id, sent_at: DateTime.now)
   end
 
   def car_reservation_remove_passenger(student, user)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -45,7 +45,6 @@ class Reservation < ApplicationRecord
   has_one :vehicle_report, dependent: :destroy
   before_destroy :car_reservation_cancel
   before_update :check_number_of_non_uofm_passengers
-  before_update :send_email_on_drivers_update
   before_create :check_recurring
   
   has_rich_text :note
@@ -141,46 +140,6 @@ class Reservation < ApplicationRecord
     end
   end
 
-  def send_email_on_drivers_update
-    drivers_emails = []
-    if self.driver_id.present? && self.driver_changed?
-      if self.driver_id_change[1].present? && self.driver_id_change[0].nil?
-        return
-      end
-    end
-    if self.driver_changed?
-      if self.driver_id_change[0].present?
-        drivers_emails << email_address(Student.find(self.driver_id_change[0]))
-      end
-      if self.driver_id_change[1].present?
-        drivers_emails << email_address(Student.find(self.driver_id_change[1]))
-      end
-    end
-    if self.driver_manager_id.present? && self.driver_manager_changed?
-      if self.driver_manager_id_change[1].present? && self.driver_manager_id_change[0].nil?
-        return
-      end
-    end
-    if self.driver_manager_changed?
-      if self.driver_manager_id_change[0].present?
-        drivers_emails << email_address(Manager.find(self.driver_manager_id_change[0]))
-      end
-      if self.driver_manager_id_change[1].present?
-        drivers_emails << email_address(Manager.find(self.driver_manager_id_change[1]))
-      end
-    end
-    if self.backup_driver_changed?
-      if self.backup_driver_id_change[0].present?
-        drivers_emails << email_address(Student.find(self.backup_driver_id_change[0]))
-      end
-      if self.backup_driver_id_change[1].present?
-        drivers_emails << email_address(Student.find(self.backup_driver_id_change[1]))
-      end
-    end
-    if drivers_emails.present?
-      ReservationMailer.car_reservation_drivers_edited(self, drivers_emails, self.reserved_by).deliver_now
-    end
-  end
 
   def check_diff_time
     if ((self.end_time - self.start_time) / 1.minute).to_i < 46

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -66,6 +66,10 @@ class ReservationPolicy < ApplicationPolicy
     user_in_access_group? || is_reserved_by?
   end
 
+  def add_edit_drivers?
+    user_in_access_group? || is_reserved_by?
+  end
+
   def add_drivers_later?
     user_in_access_group?
   end

--- a/app/views/reservations/_drivers.html.erb
+++ b/app/views/reservations/_drivers.html.erb
@@ -1,9 +1,9 @@
-<%= form_with model: [@reservation], class: "contents",
+<%= form_with(model: @reservation, url: add_edit_drivers_path,
   data: { controller: "driver",
           target: "form",
           action: "submit->driver#submitForm",
           turbo_frame: "_top"
-        } do |form| %>
+        }) do |form| %>
 
   <% if @reservation.errors.any? %>
     <div id="error_explanation" class="text-red-umred px-3 py-2 font-medium rounded-lg mt-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
   get '/reservations/add_passenger/:reservation_id', to: 'reservations/passengers#add_passenger', as: :add_passenger
 
   get '/reservations/add_drivers/:id', to: 'reservations#add_drivers', as: :add_drivers
+  patch '/reservations/add_edit_drivers/:id', to: 'reservations#add_edit_drivers', as: :add_edit_drivers
+
   delete 'reservations/:reservation_id/:student_id', to: 'reservations/passengers#remove_passenger', as: :remove_passenger
   get '/reservations/day_reservations/:date', to: 'reservations#day_reservations', as: :day_reservations
   get '/reservations/:id/add_drivers_later', to: 'reservations#add_drivers_later', as: :add_drivers_later


### PR DESCRIPTION
In reservation_controleler, move add/edit drivers from the update reservation method to the add_edit_drivers method.
Move sending update drivers email from the model to the controller 

- the code is more simple
- to prepare to update recurring reservations (multiple - at once)
  - to be able to send one email about updating drivers in recurring reservations (if sending email happened in a model the email about updating drivers would be sent for every reservation)
- can handle situations when a user clicks the Edit Drivers button without changing any fields
