### PR TITLE
New vehicle reports bug

### DIFF
--- a/app/controllers/vehicle_reports_controller.rb
+++ b/app/controllers/vehicle_reports_controller.rb
@@ -72,6 +72,16 @@ class VehicleReportsController < ApplicationController
 
     respond_to do |format|
       if @vehicle_report.save
+        car = @reservation.car
+        if @vehicle_report.mileage_end.present?
+          car.update(mileage: @vehicle_report.mileage_end)
+        end
+        if @vehicle_report.gas_end.present?
+          car.update(gas: @vehicle_report.gas_end)
+        end
+        if @vehicle_report.parking_spot_return.present?
+          car.update(parking_spot: @vehicle_report.parking_spot_return, last_used: DateTime.now, last_driver_id: @reservation.driver_id)
+        end
         format.html { redirect_to vehicle_report_url(@vehicle_report), notice: "Vehicle report was successfully created." }
         format.json { render :show, status: :created, location: @vehicle_report }
       else

--- a/app/controllers/vehicle_reports_controller.rb
+++ b/app/controllers/vehicle_reports_controller.rb
@@ -40,13 +40,6 @@ class VehicleReportsController < ApplicationController
     @vehicle_report = VehicleReport.new
     @vehicle_report.parking_spot = @reservation.car.parking_spot
     authorize @vehicle_report
-    @pictures_start_required = false
-    if @reservation.program.pictures_required_start
-      @pictures_start_required = true
-    end 
-    if @reservation.program.pictures_required_end
-      @pictures_end_required = true
-    end
   end
 
   # GET /vehicle_reports/1/edit

--- a/app/views/vehicle_reports/_form.html.erb
+++ b/app/views/vehicle_reports/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: vehicle_report, class: "contents",
+<%= form_with model: [@reservation, vehicle_report],
   data: { controller: "vehiclereport",
           target: "form",
           action: "submit->vehiclereport#submitForm"


### PR DESCRIPTION
When a vehicle report is created the car's record should be updated.
Until now the car was updated only when the vehicle report was updated.

I removed the code about pictures required from the new method. We don't need that now because we don't upload pictures in the form.