### PR TITLE
Lra 776 lsa ride share add parking locations to vehicle reports

### DIFF
--- a/app/controllers/vehicle_reports_controller.rb
+++ b/app/controllers/vehicle_reports_controller.rb
@@ -39,30 +39,48 @@ class VehicleReportsController < ApplicationController
   def new
     @vehicle_report = VehicleReport.new
     @vehicle_report.parking_spot = @reservation.car.parking_spot
+    unit = @reservation.program.unit
+    parking_prefs = UnitPreference.find_by(name: "parking_location", unit_id: unit).value
+    if parking_prefs.present?
+      @parking_locations = parking_prefs.split(',')
+      @parking_locations.each(&:strip!)
+    end
+
     authorize @vehicle_report
   end
 
   # GET /vehicle_reports/1/edit
   def edit
-    unless @vehicle_report.approved
-      @reservation = @vehicle_report.reservation
-      if @reservation.program.pictures_required_start
-        @pictures_start_required = true
-      end 
-      if @reservation.program.pictures_required_end
-        @pictures_end_required = true
-      end
-    else
-      flash.now[:alert] = 'The vehicle report is approved. Please reload the page. To edit, please contact your administrator'
+    if @vehicle_report.approved
+      flash.now[:alert] = 'The vehicle report is approved. Please reload the page. To edit, please contact your administrator.'
       render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+    end
+    @reservation = @vehicle_report.reservation
+    unit = @reservation.program.unit
+    parking_prefs = UnitPreference.find_by(name: "parking_location", unit_id: unit).value
+    if parking_prefs.present?
+      @parking_locations = parking_prefs.split(',')
+      @parking_locations.each(&:strip!)
+      if @parking_locations.map(&:downcase).include?("other")
+        @other = true
+      else 
+        @other = false
+      end
+      if @vehicle_report.parking_spot_return.present? && @parking_locations.exclude?(@vehicle_report.parking_spot_return)
+        @current_parking_return = @vehicle_report.parking_spot_return
+      else
+        @current_parking_return = ""
+      end
     end
   end
 
   # POST /vehicle_reports or /vehicle_reports.json
   def create
     @vehicle_report = VehicleReport.new(vehicle_report_params)
+    if params[:parking_spot_return_select].present? && params[:parking_spot_return_select].downcase != "other"
+      @vehicle_report.parking_spot_return = params[:parking_spot_return_select]
+    end
     authorize @vehicle_report
-
     respond_to do |format|
       if @vehicle_report.save
         car = @reservation.car
@@ -87,7 +105,12 @@ class VehicleReportsController < ApplicationController
   # PATCH/PUT /vehicle_reports/1 or /vehicle_reports/1.json
   def update
     @reservation = @vehicle_report.reservation
-
+    @vehicle_report.attributes = vehicle_report_params
+    if params[:parking_spot_return_select].present? && params[:parking_spot_return_select].downcase != "other"
+      @vehicle_report.parking_spot_return = params[:parking_spot_return_select]
+    elsif params[:parking_spot_return].present?
+      @vehicle_report.parking_spot_return = params[:parking_spot_return]
+    end
     respond_to do |format|
       if @vehicle_report.update(vehicle_report_params)
         car = @vehicle_report.reservation.car
@@ -191,7 +214,7 @@ class VehicleReportsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def vehicle_report_params
       params.require(:vehicle_report).permit(:reservation_id, :mileage_start, :mileage_end, 
-                    :gas_start, :gas_end, :parking_spot, :parking_spot_return, :image_front_start, :image_driver_start, 
+                    :gas_start, :gas_end, :parking_spot, :parking_spot_return, :parking_spot_return_select, :image_front_start, :image_driver_start, 
                     :image_passenger_start, :image_back_start, :image_front_end, :image_driver_end, 
                     :image_passenger_end, :image_back_end, :created_by, :updated_by, :status, :comment,
                     :approved, :damage_form, image_damages: [] )

--- a/app/controllers/vehicle_reports_controller.rb
+++ b/app/controllers/vehicle_reports_controller.rb
@@ -79,6 +79,8 @@ class VehicleReportsController < ApplicationController
     @vehicle_report = VehicleReport.new(vehicle_report_params)
     if params[:parking_spot_return_select].present? && params[:parking_spot_return_select].downcase != "other"
       @vehicle_report.parking_spot_return = params[:parking_spot_return_select]
+    elsif params[:parking_spot_return].present?
+      @vehicle_report.parking_spot_return = params[:parking_spot_return]
     end
     authorize @vehicle_report
     respond_to do |format|

--- a/app/javascript/controllers/vehiclereport_controller.js
+++ b/app/javascript/controllers/vehiclereport_controller.js
@@ -2,19 +2,38 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ['form', 'gas_start',
-          'mileage_error', 'mileage_start', 'mileage_end']
+          'mileage_error', 'mileage_start', 'mileage_end',
+          'parking_return', 'parking_other_div', 'parking_other']
   connect() {
     console.log("connect - vehicle report")
   }
 
+  otherParking(){
+    var parking_return = this.parking_returnTarget.value.toLowerCase()
+    var parking_other_error_place = document.getElementById('parking_other_error_place')
+    if (parking_return == 'other') {
+      this.parking_otherTarget.value = ""
+      this.parking_other_divTarget.classList.remove("fields--hide")
+      this.parking_other_divTarget.classList.add("fields--display")
+    }
+    else {
+      this.parking_otherTarget.value = ""
+      parking_other_error_place.innerHTML = ''
+      this.parking_other_divTarget.classList.add("fields--hide")
+      this.parking_other_divTarget.classList.remove("fields--display")
+    }
+  }
+
   submitForm(event) {
-    
     var gas_start = this.gas_startTarget.value
     var mileage_start = Number(this.mileage_startTarget.value)
     var mileage_end = Number(this.mileage_endTarget.value)
     var mileage_error_place = document.getElementById('mileage_show_error')
     var gas_error_place = document.getElementById('gas_error')
     var error_scroll_place = document.getElementById('error_scroll_place')
+    var parking_return = this.parking_returnTarget.value.toLowerCase()
+    var parking_other = this.parking_otherTarget.value
+    var parking_other_error_place = document.getElementById('parking_other_error_place')
   
     var submitForm = true
 
@@ -39,12 +58,21 @@ export default class extends Controller {
       submitForm = false
     }
 
+    parking_other_error_place.innerHTML = ''
+    if(parking_return == "other" && parking_other == "") {
+      parking_other_error_place.innerHTML = "Please enter the other parking spot"
+      submitForm = false
+    }
+    if (parking_return != "other"){
+      this.parking_otherTarget.value = ""
+    }
+
     if(submitForm == false) {
       event.preventDefault()
     }
-    else {
-      Turbo.navigator.submitForm(this.formTarget)
-    }
+    // else {
+    //   Turbo.navigator.submitForm(this.formTarget)
+    // }
   }
 
 }

--- a/app/views/vehicle_reports/_form.html.erb
+++ b/app/views/vehicle_reports/_form.html.erb
@@ -72,9 +72,31 @@
         <%= form.text_field :parking_spot, placeholder: "Parking Spot (depart)", class: "input_text_field" %>
       </div>
 
-            <div class="my-5">
-        <%= form.label :parking_spot_return, 'Parking Spot (return)', class: "fancy_label"  %>
-        <%= form.text_field :parking_spot_return, placeholder: "Parking Spot (return)", class: "input_text_field" %>
+      <div class="my-5">
+        <% if @parking_locations.present? %>
+          <% if @vehicle_report.persisted? && @current_parking_return.present? %>
+            <div class="py-2">
+              <label class="body-lg-bold-text">
+                Current Parking Spot (return):
+              </label>
+              <p class="body-lg-text ml-2 inline-block">
+                <%= @current_parking_return %>
+              </p>
+            </div>
+          <% end %>
+          <%= label_tag 'Parking Spot (return)', nil, class: "fancy_label" %>
+          <%= select_tag "parking_spot_return_select", options_for_select(@parking_locations, @vehicle_report.parking_spot_return), include_blank: "Select ...", class: "input_text_field",
+            "data-vehiclereport-target": "parking_return", "data-action": "vehiclereport#otherParking" %>
+          <div data-vehiclereport-target="parking_other_div" class="my-5 fields--hide">
+            <%= label_tag 'Other Parking Spot (return)', nil, class: "fancy_label" %>
+            <%= text_field_tag(:parking_spot_return, nil, { class: "input_text_field", "data-vehiclereport-target": "parking_other" }) %>
+          </div>
+          <div class="error_text" id="parking_other_error_place">
+          </div>
+        <% else %>
+          <%= form.label :parking_spot_return, 'Parking Spot (return)', class: "fancy_label"  %>
+          <%= form.text_field :parking_spot_return, placeholder: "Parking Spot (return)", class: "input_text_field" %>
+        <% end %>
       </div>
 
     </div>


### PR DESCRIPTION
First, create a new unit preference:

- Go to http://localhost:3000/unit_preferences
- name: parking_location
- description: Comma-separated list of parking locations (Add 'Other' at the end of the list to allow other locations)
- type: string
- Create Unit Preference
- To use this preference Go To Unit Options -> Unit Preferences, add the list of parking locations, and save preferences.

Description of possible cases:

- Unit Preference ‘parking_location’ is empty
- Unit Preference ‘parking_location’ is not empty, and **doesn’t have** an ‘Other’ location
  - For example: ‘parking one, parking two, parking three’
- Unit Preference ‘parking_location’ is not empty, and **has** ‘Other’ location
  - For example: ‘parking one, parking two, parking three, Other’

How does it work:

- parking_spot_return is always saved as a string in the vehicle_reports table
- The Vehicle Report's form displays the drop-down list of parking locations if the parking_location preference has some values
- If the drop-down list has an ‘Other’ option, a text field will be displayed if the ‘Other’ option is selected.
- If the parking_spot_returned value, that was saved in the database, does not match any options in the drop-down list, the current (saved) locations will be displayed on the edit form
- if an option from the drop-down list is selected before the form is submitted the new value will be saved in the database

To test:

- Create a new Vehicle Report for every case (listed in the possible cases above)
- Edit a Vehicle Report for every case
- Do not create a ‘parking_location’ preference (empty list)
  - create a vehicle report with a custom parking spot;
  - create a ‘parking_location’ preference
  - open the report to edit
- Open old vehicle reports (created before parking spots were introduced) and see that they are correct

Please let me know if you have any questions.
