### PR TITLE
LRA-750 LSA RideShare - what to do if students drop a program but are in reservations

### DIFF
--- a/app/controllers/concerns/student_api.rb
+++ b/app/controllers/concerns/student_api.rb
@@ -83,7 +83,14 @@ module StudentApi
         end
         if students_in_db_registered.present?
           # delete students who dropped the course
-          Student.where(uniqname: students_in_db_registered, program_id: @student_program).delete_all
+          students_in_db_registered.each do |uniqname|
+            student = Student.where(uniqname: students_in_db_registered, program_id: @student_program)
+            if student.reservations.present?
+              student.update(registered: false)
+            else
+              student.delete
+            end
+          end
         end
         unless @student_program.update(number_of_students: @student_program.students.count)
           flash.now[:error] = "Error updating number of students."

--- a/app/controllers/concerns/student_api.rb
+++ b/app/controllers/concerns/student_api.rb
@@ -84,7 +84,7 @@ module StudentApi
         if students_in_db_registered.present?
           # delete students who dropped the course
           students_in_db_registered.each do |uniqname|
-            student = Student.where(uniqname: students_in_db_registered, program_id: @student_program)
+            student = Student.find_by(uniqname: students_in_db_registered, program_id: @student_program)
             if student.reservations.present?
               student.update(registered: false)
             else

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -76,7 +76,7 @@ class Student < ApplicationRecord
   end
 
   def reservations
-    reservations_past + reservations_future
+    reservations_current + reservations_past + reservations_future
   end
 
   def display_name


### PR DESCRIPTION
If a student drops a program

- if the student has reservations - should be moved to non-registered students
  - this is what was done in the pull request; that caused the error until now
- if the student has no reservations - should be deleted from the program
  - this is the current behavior

To Test 

- create a program (or edit a program) with a real course (check staging server for CEAL or Psychology programs)
- get students list
- manually add um174887 to students' list
  - don't go back to the student list
- in the bin/rails console update the student: update(registered: true)
- reload the page in the browser
  - the student is registered
- create a reservation with this student or add the student to an existing reservation (add to passengers; to make the student a driver you have to update the student's record to make the student an eligible driver)
- open the program's student list
  - notice that um174487 student is not registered
