### PR TITLE
Lra 780 lsa ride share remove reservation from recurring if it was edited separately again

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -385,16 +385,6 @@ class ReservationsController < ApplicationController
     if params[:recurring] == "true"
       notice = recurring_reservation.update_drivers(reservation_params.to_h) + note
     else
-      if @reservation.recurring.present?
-        recurring_reservation = RecurringReservation.new(@reservation)
-        result = recurring_reservation.remove_from_list
-        if result == ""
-          note += " Reservation was removed from the list of recurring reservations."
-        else
-          redirect_to reservation_path(@reservation), alert: note + result
-          return
-        end
-      end
       if @reservation.update(reservation_params)
         notice = "Drivers were updated." + note
       else
@@ -403,6 +393,16 @@ class ReservationsController < ApplicationController
     end
     if success
       if params[:edit] == "true"
+        if @reservation.recurring.present?
+          recurring_reservation = RecurringReservation.new(@reservation)
+          result = recurring_reservation.remove_from_list
+          if result == ""
+            note += " Reservation was removed from the list of recurring reservations."
+          else
+            redirect_to reservation_path(@reservation), alert: note + result
+            return
+          end
+        end
         @reservation = Reservation.find(params[:id])
         drivers_emails_new = reservation_drivers_emails
         if drivers_emails == drivers_emails_new

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -312,9 +312,10 @@ class ReservationsController < ApplicationController
         recurring_reservation = RecurringReservation.new(@reservation)
         note = recurring_reservation.remove_from_list
         if note == ""
-          notice = " Reservation was removed fron the list of recurring reservations."
+          notice = " Reservation was removed from the list of recurring reservations."
         else
           redirect_to reservation_path(@reservation), notice: "Reservation was not updated." + note
+          return
         end
       end
       @reservation.attributes = reservation_params
@@ -384,6 +385,16 @@ class ReservationsController < ApplicationController
     if params[:recurring] == "true"
       notice = recurring_reservation.update_drivers(reservation_params.to_h) + note
     else
+      if @reservation.recurring.present?
+        recurring_reservation = RecurringReservation.new(@reservation)
+        result = recurring_reservation.remove_from_list
+        if result == ""
+          note += " Reservation was removed from the list of recurring reservations."
+        else
+          redirect_to add_passengers_path(@reservation), notice: note + result
+          return
+        end
+      end
       if @reservation.update(reservation_params)
         notice = "Drivers were updated." + note
       else

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -391,7 +391,7 @@ class ReservationsController < ApplicationController
         if result == ""
           note += " Reservation was removed from the list of recurring reservations."
         else
-          redirect_to add_passengers_path(@reservation), notice: note + result
+          redirect_to reservation_path(@reservation), alert: note + result
           return
         end
       end
@@ -503,6 +503,16 @@ class ReservationsController < ApplicationController
     else
       recurring = false
       notice = "Passengers list was updated."
+      if @reservation.recurring.present?
+        recurring_reservation = RecurringReservation.new(@reservation)
+        note = recurring_reservation.remove_from_list
+        if note == ""
+          notice += " Reservation was removed from the list of recurring reservations."
+        else
+          redirect_to reservation_path(@reservation), alert: note
+          return
+        end
+      end
     end
     ReservationMailer.with(reservation: @reservation).car_reservation_update_passengers(current_user, recurring).deliver_now
     redirect_to reservation_path(@reservation), notice: notice

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -509,7 +509,7 @@ class ReservationsController < ApplicationController
         if note == ""
           notice += " Reservation was removed from the list of recurring reservations."
         else
-          redirect_to reservation_path(@reservation), alert: note
+          redirect_to reservation_path(@reservation), alert: notice + note
           return
         end
       end

--- a/app/models/recurring_reservation.rb
+++ b/app/models/recurring_reservation.rb
@@ -78,7 +78,7 @@ class RecurringReservation
     list.each do |id|
       reservation = Reservation.find(id)
       unless reservation.update(params)
-        note += "Reservation #{id} was not updated: " + reservation.errors.full_messages.join(',') + ". "
+        note += " Reservation #{id} was not updated: " + reservation.errors.full_messages.join(',') + ". "
       end
     end
     if note == ""
@@ -119,22 +119,22 @@ class RecurringReservation
     note = ""
     if prev_reservation && next_reservation
       unless next_reservation.update(prev: prev_reservation.id)
-        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+        note += " Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
       end
       unless prev_reservation.update(next: next_reservation.id)
-        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+        note += " Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
       end
     elsif prev_reservation
       unless prev_reservation.update(next: nil)
-        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+        note += " Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
       end
     elsif next_reservation
       unless next_reservation.update(prev: nil)
-        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+        note += " Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
       end
     end
     unless @reservation.update(recurring: nil, prev: nil, next: nil)
-      note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+      note += " Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
     end
     return note
   end

--- a/app/models/recurring_reservation.rb
+++ b/app/models/recurring_reservation.rb
@@ -115,6 +115,30 @@ class RecurringReservation
     return Array(@reservation.id)
   end
 
+  def remove_from_list
+    note = ""
+    if prev_reservation && next_reservation
+      unless next_reservation.update(prev: prev_reservation.id)
+        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+      end
+      unless prev_reservation.update(next: next_reservation.id)
+        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+      end
+    elsif prev_reservation
+      unless prev_reservation.update(next: nil)
+        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+      end
+    elsif next_reservation
+      unless next_reservation.update(prev: nil)
+        note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+      end
+    end
+    unless @reservation.update(recurring: nil, prev: nil, next: nil)
+      note += "Error removing reservation #{id} from the recurring list: " + reservation.errors.full_messages.join(',') + ". "
+    end
+    return note
+  end
+
   def get_following_to_delete
     prev_reservation.update(next: nil)
     list = Array(@reservation.id)

--- a/app/models/recurring_reservation.rb
+++ b/app/models/recurring_reservation.rb
@@ -140,7 +140,9 @@ class RecurringReservation
   end
 
   def get_following_to_delete
-    prev_reservation.update(next: nil)
+    if prev_reservation.present?
+      prev_reservation.update(next: nil)
+    end
     list = Array(@reservation.id)
     next_id = @reservation.next
     until next_id.nil? do

--- a/app/views/reservations/passengers/add_passengers.html.erb
+++ b/app/views/reservations/passengers/add_passengers.html.erb
@@ -2,9 +2,12 @@
   <div class="lg:flex justify-between items-center mb-4">
     <div>
       <% if params["edit"] %>
-        <h1>Edit Passengers</h1>
-        <% if params["all_recurring"] == "true" %>
+        <h1 class="inline">Edit Passengers</h1>
+        <% if params["recurring"] == "true" %>
           <h2>for All Recurring Reservations</h2>
+          <p class="body-sm-text ml-2">
+            Click on the Go Back to Reservation Page button after editing
+          </p>
           <div class="pt-4 pb-2">
             <% recurring_reservation = RecurringReservation.new(@reservation) %>
             <p class="body-lg-bold-text inline">
@@ -18,6 +21,9 @@
         <% end %>
       <% else %>
         <h1>Add Passengers</h1>
+        <p class="body-sm-text ml-2">
+          Click on the Finish Creating Reservation button after adding passengers
+        </p>
       <% end %>
       <h2>
         <%= @reservation.program.display_name_with_title %>

--- a/app/views/reservations/passengers/add_passengers.html.erb
+++ b/app/views/reservations/passengers/add_passengers.html.erb
@@ -18,6 +18,10 @@
               <%= recurring_reservation.first_reservation.rule.to_s %>
             </p>
           </div>
+        <% else %>
+          <p class="body-sm-text ml-2">
+            Click on the Go Back to Reservation Page button after editing
+          </p>
         <% end %>
       <% else %>
         <h1>Add Passengers</h1>

--- a/app/views/system_reports/index.html.erb
+++ b/app/views/system_reports/index.html.erb
@@ -38,11 +38,11 @@
       </div>
 
       <div class="my-2 fields--display" data-systemreport-target="run_report_button">
-        <%= f.submit "Run report", data: { disable_with: false }, method: :get, class: "primary_button" %>
+        <%= f.submit "Run Report", data: { disable_with: false }, method: :get, class: "primary_button" %>
       </div>
 
       <div class="fields--hide my-4" data-systemreport-target="download_report_button">
-        <a id="csv_link" href="" class="primary_button">Download report</a>
+        <a id="csv_link" href="" class="primary_button">Download Report</a>
       </div>
 
     <% end %>


### PR DESCRIPTION
If a recurring reservation is edited separately (users click on Update Reservation, Edit Drivers, or Edit Passengers on the show page for a recurring reservation) the reservation should be removed from the list of recurring reservations after editing is done.

The reservation_controller's methods: update, add_edit_drivers, and update_passengers check if the reservation is recurring  but is edited as an individual reservation (params[:recurring] is not present). If that is true the methods call recurring_reservation.remove_from_list. 

The remove_from_list method in the recurring_reservation.rb file (in the models folder) is doing updates to remove a recurring reservation from the list.

To test:

- create recurring reservations 
- edit one of them individually
- look at the after-update message
- notice that there is no recurring information for this reservation on the page
- look at the Reservations index calendar for that reservation: it doesn't have recurring icon any more.

To look at the list of recurring reservations in the bin/rails console:
create the list of all recurring reservations (ID is the id of the first recurring reservation)
```
r = Reservation.find(ID)
recurring_reservation = RecurringReservation.new(r)
result = recurring_reservation.get_all_reservations
Reservation.where(id: result).order(:id).pluck(:prev, :id, :next, :start_time, :end_time)
```

Edit one of the reservations separately. Repeat the above four commands again.
Compare the outputs of the last commands
 



