### PR TITLE
Lra 781 lsa ride share admins should be able to add managers as drivers

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -350,40 +350,36 @@ class ReservationsController < ApplicationController
   def add_edit_drivers
     success = true
     recurring = false
+    note = ""
     drivers_emails = reservation_drivers_emails
+    @reservation.attributes = reservation_params
     if params[:recurring] == "true"
       recurring_reservation = RecurringReservation.new(@reservation)
       recurring = true
     end
-    if @reservation.driver_manager.present? && params[:reservation][:driver_id].present?
-      if params[:recurring] == "true"
-        reservations_to_update = recurring_reservation.get_following
-        Reservation.where(id: reservations_to_update).update_all(driver_manager: nil)
-      else
-        @reservation.update(driver_manager: nil)
+    # check if a new driver is a student or a manager
+    driver_param = params[:driver_id].split("-")
+    driver_type = driver_param[1]
+    driver_id = driver_param[0].to_i
+    if driver_type == "student"
+      @reservation.driver_id = driver_id
+      @reservation.driver_manager_id = nil
+    elsif driver_type == "manager"
+      @reservation.driver_manager_id = driver_id
+      @reservation.driver_id = nil
+    end
+    if params[:edit] == "true"
+      # check if a new driver is a passenger
+      note = check_if_driver_is_passenger(@reservation, driver_type, "Driver", driver_id, recurring)
+      # check if a new backup driver is a passenger
+      if params[:reservation][:backup_driver_id].present? 
+        note += check_if_driver_is_passenger(@reservation, "student", "Backup Driver", params[:reservation][:backup_driver_id], recurring)
       end
     end
-    # check if a new driver is a passenger
-    note = ""
-    if params[:reservation][:driver_id].present? && @reservation.passengers.include?(Student.find(params[:reservation][:driver_id]))
-      if params[:recurring] == "true"
-        recurring_reservation.remove_passenger_following_reservations(Student.find(params[:reservation][:driver_id]))
-      else
-        @reservation.passengers.delete(Student.find(params[:reservation][:driver_id]))
-      end
-      note += " Driver was removed from passengers list."
-    end
-    if params[:reservation][:backup_driver_id].present? && @reservation.passengers.include?(Student.find(params[:reservation][:backup_driver_id]))
-      if params[:recurring] == "true"
-        recurring_reservation.remove_passenger_following_reservations(Student.find(params[:reservation][:backup_driver_id]))
-      else
-        @reservation.passengers.delete(Student.find(params[:reservation][:backup_driver_id]))
-      end
-      note += " Backup Driver was removed from passengers list."
-    end
-
     if params[:recurring] == "true"
-      notice = recurring_reservation.update_drivers(reservation_params.to_h) + note
+      list_of_params = reservation_params.to_h
+      list_of_params["driver_id"] = params[:driver_id]
+      notice = recurring_reservation.update_drivers(list_of_params) + note
     else
       if @reservation.update(reservation_params)
         notice = "Drivers were updated." + note
@@ -420,7 +416,8 @@ class ReservationsController < ApplicationController
         return
       end
     else
-      @drivers = @reservation.program.students.eligible_drivers
+      @drivers = list_of_drivers(@reservation)
+      @driver = reservation_driver(@reservation)
       render :add_drivers, status: :unprocessable_entity
       return
     end
@@ -462,7 +459,9 @@ class ReservationsController < ApplicationController
 
   def add_drivers
     @drivers = @reservation.program.students.eligible_drivers
+    @all_drivers = list_of_drivers(@reservation)
     @passengers = @reservation.passengers
+    @driver = reservation_driver(@reservation)
     unless is_admin?(current_user)
       if is_student?(current_user)
         driver = Student.find_by(program_id: @reservation.program_id, uniqname: current_user.uniqname)
@@ -629,17 +628,58 @@ class ReservationsController < ApplicationController
     end
 
     def reservation_drivers_emails
-      drivers_emails = []
+      emails = []
       if @reservation.driver.present?
-        drivers_emails << email_address(@reservation.driver)
+        emails << email_address(@reservation.driver)
       end
       if @reservation.backup_driver.present?
-        drivers_emails << email_address(@reservation.backup_driver)
+        emails << email_address(@reservation.backup_driver)
       end
       if @reservation.driver_manager.present?
-        drivers_emails << email_address(@reservation.driver_manager)
+        emails << email_address(@reservation.driver_manager)
       end
-      return drivers_emails
+      return emails
+    end
+
+    def list_of_drivers(reservation)
+      drivers = reservation.program.students.eligible_drivers.map { |d| [d.display_name, d.id.to_s + "-student"] }
+      manager_drivers = reservation.program.managers.eligible_drivers.map { |d| [d.display_name + " (manager)", d.id.to_s + "-manager"] }
+      if reservation.program.instructor.can_reserve_car?
+        manager_drivers << [reservation.program.instructor.display_name + " (instructor)", reservation.program.instructor_id.to_s + "-manager"]
+      end
+      if is_admin?(current_user)
+        drivers.concat manager_drivers
+      end
+      return drivers
+    end
+
+    def reservation_driver(reservation)
+      driver = []
+      if reservation.driver_id.present?
+        driver = [reservation.driver.display_name, reservation.driver_id.to_s + "-student"]
+      elsif reservation.driver_manager_id.present?
+        driver = [reservation.driver_manager.display_name, reservation.driver_manager_id.to_s + "-manager"]
+      else
+        nil
+      end
+    end
+
+    def check_if_driver_is_passenger(reservation, driver_type, field, driver_id, recurring)
+      # check if a new driver is a passenger
+      note = ""
+      if driver_type == "student"
+        student = Student.find(driver_id)
+        if @reservation.passengers.include?(student)
+          if recurring
+            recurring_reservation = RecurringReservation.new(reservation)
+            recurring_reservation.remove_passenger_following_reservations(student)
+          else
+            reservation.passengers.delete(student)
+          end
+          note = " " + field + " was removed from passengers list."
+        end
+      end
+      return note
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -389,7 +389,7 @@ class ReservationsController < ApplicationController
     end
     if success
       if params[:edit] == "true"
-        if @reservation.recurring.present?
+        if params[:recurring].empty? && @reservation.recurring.present?
           recurring_reservation = RecurringReservation.new(@reservation)
           result = recurring_reservation.remove_from_list
           if result == ""

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -477,9 +477,8 @@ module ApplicationHelper
     return false unless is_student?(current_user)
     return false unless Student.find_by(uniqname: current_user.uniqname, program_id: reservation.program).present?
     student = Student.find_by(uniqname: current_user.uniqname, program_id: reservation.program)
-    return false if student.passenger_future.include?(reservation)
     return false if reservation.backup_driver == student
-    if ((reservation.start_time - DateTime.now.beginning_of_day)/3600).round > minimum_hours_before_reservation(reservation.program.unit)
+    if reservation.driver == student && ((reservation.start_time - DateTime.now.beginning_of_day)/3600).round > minimum_hours_before_reservation(reservation.program.unit)
       return true
     else
       return false
@@ -488,14 +487,9 @@ module ApplicationHelper
 
   def allow_manager_to_edit_reservation?(reservation)
     return false unless is_manager?(current_user)
-    manager = Manager.find_by(uniqname: current_user.uniqname)
-    return true if reservation.reserved_by = current_user.id
-    # if reservation.driver_manager_id.present?
-    #   return false unless Manager.find(reservation.driver_manager_id).uniqname == current_user.uniqname
-    # else 
-    #   return false
-    # end
-    if ((reservation.start_time - DateTime.now.beginning_of_day)/3600).round > minimum_hours_before_reservation(reservation.program.unit)
+    return false unless reservation.driver_manager_id.present?
+    # return true if reservation.reserved_by = current_user.id
+    if reservation.driver_manager.uniqname == current_user.uniqname && ((reservation.start_time - DateTime.now.beginning_of_day)/3600).round > minimum_hours_before_reservation(reservation.program.unit)
       return true
     else
       return false
@@ -515,6 +509,18 @@ module ApplicationHelper
       "Completed"
     else
       "Not Completed"
+    end
+  end
+
+  def allow_add_vehicle_report?(reservation, user)
+    if is_admin?(user)
+      return true
+    else
+      if Reservation.no_or_not_complete_vehicle_reports.exists?(reservation.id)
+        return true
+      else
+        return false
+      end
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -473,6 +473,18 @@ module ApplicationHelper
     end
   end
 
+  def allow_user_to_cancel_reservation?(reservation)
+    return false if reservation.approved
+    return true if is_admin?(current_user)
+    if User.find(reservation.reserved_by) == current_user
+      return true if allow_student_to_edit_reservation?(reservation) || allow_manager_to_edit_reservation?(reservation)
+    else
+      return false
+    end
+  end
+
+
+
   def allow_student_to_edit_reservation?(reservation)
     return false unless is_student?(current_user)
     return false unless Student.find_by(uniqname: current_user.uniqname, program_id: reservation.program).present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -335,14 +335,22 @@ module ApplicationHelper
   def unit_begining_of_day(day, unit_id)
     t_begin = UnitPreference.find_by(name: "reservation_time_begin", unit_id: unit_id).value
     t_begin = Time.parse(t_begin).strftime("%H").to_i
-    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+    if (day.to_time + 2.hour).dst?
+      day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+    else
+      day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EST')
+    end
     return day_begin
   end
 
   def unit_end_of_day(day, unit_id)
     t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
     t_end = Time.parse(t_end).strftime("%H").to_i
-    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    if (day.to_time + 2.hour).dst?
+      day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    else
+      day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EST')
+    end
     return day_end
   end
 
@@ -351,8 +359,13 @@ module ApplicationHelper
     t_begin = Time.parse(t_begin).strftime("%H").to_i
     t_end = UnitPreference.find_by(name: "reservation_time_end", unit_id: unit_id).value
     t_end = Time.parse(t_end).strftime("%H").to_i
-    day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
-    day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    if (day.to_time + 2.hour).dst?
+      day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EDT')
+      day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EDT')
+    else
+      day_begin = DateTime.new(day.year, day.month, day.day, t_begin, 0, 0, 'EST')
+      day_end = DateTime.new(day.year, day.month, day.day, t_end, 0, 0, 'EST')
+    end
     return [day_begin, day_end]
   end
 

--- a/app/javascript/controllers/driver_controller.js
+++ b/app/javascript/controllers/driver_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
   }
 
   submitForm(event) {
-    var driver = this.driverTarget.value
+    var driver = this.driverTarget.value.split('-')[0]
     var driver_phone = this.driver_phoneTarget.value
     var number = this.number_of_people_on_tripTarget.value - this.number_of_passengersTarget.value  - 1
     var driver_error_place = document.getElementById('driver_error')

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -65,12 +65,11 @@ class Manager < ApplicationRecord
   end
 
   def reservations_current
-    Reservation.current_term.where("reserved_by = ? OR driver_manager_id = ?", User.find_by(uniqname: self.uniqname), self.id).where("(start_time BETWEEN ? AND ?) OR (start_time < ? AND end_time > ?)",
-    Date.today.beginning_of_day, Date.today.end_of_day, Date.today.end_of_day, Date.today.beginning_of_day)
+    Reservation.no_or_not_complete_vehicle_reports.where('(reserved_by = ? OR driver_manager_id = ?)', User.find_by(uniqname: self.uniqname), self.id)
   end
 
   def reservations_past
-    Reservation.current_term.where('(reserved_by = ? OR driver_manager_id = ?) AND end_time < ?', User.find_by(uniqname: self.uniqname), self.id, Date.today.beginning_of_day)
+    Reservation.complete_vehicle_reports.where('(reserved_by = ? OR driver_manager_id = ?)', User.find_by(uniqname: self.uniqname), self.id)
   end
 
   def reservations_future

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -65,16 +65,16 @@ class Manager < ApplicationRecord
   end
 
   def reservations_current
-    Reservation.current_term.where(reserved_by: User.find_by(uniqname: self.uniqname)).where("(start_time BETWEEN ? AND ?) OR (start_time < ? AND end_time > ?)",
+    Reservation.current_term.where("reserved_by = ? OR driver_manager_id = ?", User.find_by(uniqname: self.uniqname), self.id).where("(start_time BETWEEN ? AND ?) OR (start_time < ? AND end_time > ?)",
     Date.today.beginning_of_day, Date.today.end_of_day, Date.today.end_of_day, Date.today.beginning_of_day)
   end
 
   def reservations_past
-    Reservation.current_term.where('reserved_by = ? AND end_time < ?', User.find_by(uniqname: self.uniqname), Date.today.beginning_of_day)
+    Reservation.current_term.where('(reserved_by = ? OR driver_manager_id = ?) AND end_time < ?', User.find_by(uniqname: self.uniqname), self.id, Date.today.beginning_of_day)
   end
 
   def reservations_future
-    Reservation.current_term.where('reserved_by = ? AND start_time > ?', User.find_by(uniqname: self.uniqname), Date.today.end_of_day)
+    Reservation.current_term.where('(reserved_by = ? OR driver_manager_id = ?) AND start_time > ?', User.find_by(uniqname: self.uniqname), self.id, Date.today.end_of_day)
   end
 
   def display_name

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -49,10 +49,10 @@ class Manager < ApplicationRecord
   end
 
   def self.eligible_drivers
-    mvr_status.canvas_pass.meeting_with_admin
+    mvr_status_pass.canvas_pass.meeting_with_admin_pass
   end
 
-  def self.mvr_status
+  def self.mvr_status_pass
     where("mvr_status LIKE ?", "Approved%")
   end
 
@@ -60,8 +60,8 @@ class Manager < ApplicationRecord
     where.not(canvas_course_complete_date: nil) 
   end
 
-  def self.class_training
-    where.not(class_training_date: nil) 
+  def self.meeting_with_admin_pass
+    where.not(meeting_with_admin_date: nil) 
   end
 
   def reservations_current

--- a/app/models/recurring_reservation.rb
+++ b/app/models/recurring_reservation.rb
@@ -93,7 +93,7 @@ class RecurringReservation
       params["driver_id"] = driver_id
     elsif driver_type == "manager"
       params["driver_manager_id"] = driver_id
-      params.delete("driver_id")
+      params["driver_id"] = nil
     end
     list.each do |id|
       reservation = Reservation.find(id)

--- a/app/models/recurring_reservation.rb
+++ b/app/models/recurring_reservation.rb
@@ -75,6 +75,15 @@ class RecurringReservation
   def update_drivers(params)
     list = get_following
     note = ""
+    driver_param = params[:driver_id].split("-")
+    driver_type = driver_param[1]
+    driver_id = driver_param[0].to_i
+    if driver_type == "student"
+      params["driver_id"] = driver_id
+    elsif driver_type == "manager"
+      params["driver_manager_id"] = driver_id
+      params.delete("driver_id")
+    end
     list.each do |id|
       reservation = Reservation.find(id)
       unless reservation.update(params)

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -92,10 +92,10 @@ class Student < ApplicationRecord
   end
   
   def self.eligible_drivers
-    mvr_status.canvas_pass.meeting_with_admin
+    mvr_status_pass.canvas_pass.meeting_with_admin
   end
 
-  def self.mvr_status
+  def self.mvr_status_pass
     where("mvr_status LIKE ?", "Approved%")
   end
 

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -15,7 +15,7 @@ class ReservationPolicy < ApplicationPolicy
   end
 
   def show?
-    user_in_access_group? || is_reservation_student?
+    user_in_access_group? || is_in_reservation?
   end
 
   def create?
@@ -106,9 +106,16 @@ class ReservationPolicy < ApplicationPolicy
     user_in_access_group?
   end
 
-  def is_reservation_student?
-    student = Student.find_by(program_id: @record.program, uniqname: @user.uniqname)
-    @record.driver == student || @record.backup_driver == student || @record.passengers.include?(student)
+  def is_in_reservation?
+    if is_student?
+      student = Student.find_by(program_id: @record.program, uniqname: @user.uniqname)
+      return @record.driver == student || @record.backup_driver == student || @record.passengers.include?(student)
+    end
+    if is_manager?
+      manager = Manager.find_by(uniqname: @user.uniqname)
+      return @record.driver_manager == manager || is_reserved_by?
+    end
+    return false
   end
 
   def is_reservation_driver?

--- a/app/views/reservations/_drivers.html.erb
+++ b/app/views/reservations/_drivers.html.erb
@@ -35,26 +35,15 @@
       </p>
     </div>
     <% if is_student?(current_user) %>
-      <input type="hidden" name="reservation[driver_id]" id="reservation_driver_id" value=<%= @reservation.driver_id %> data-driver-target="driver">
+      <input type="hidden" name="driver_id" id="driver_id" value=<%= @reservation.driver_id.to_s + "-student" %> data-driver-target="driver">
     <% end %>
     <% if is_manager?(current_user) %>
-      <input type="hidden" name="reservation[driver_manager_id]" id="reservation_driver_manager_id" value=<%= @reservation.driver_manager_id %> data-driver-target="driver">
+      <input type="hidden" name="driver_id" id="driver_id" value=<%= @reservation.driver_manager_id.to_s + "-manager" %> data-driver-target="driver">
     <% end %>
   <% else %>
-    <% if @reservation.driver_manager.present? %>
-      <div class="mt-2">
-        <p class="body-lg-bold-text inline">
-          Driver:
-        </p>
-        <p class="body-lg-text ml-2 inline">
-          <%= @reservation.driver_manager.display_name + " (manager)" %>
-        </p>
-      </div>
-      <input type="hidden" name="reservation[driver_manager_id]" id="reservation_driver_manager_id" value=<%= @reservation.driver_manager_id %> data-driver-target="driver">
-    <% end %>
     <div class="my-5">
-      <%= form.label :driver_id, "Driver *", class: "fancy_label" %>
-      <%= form.collection_select :driver_id, @drivers, :id, :display_name, { include_blank: "Select ..." }, class: "input_text_field",
+      <label for="driver_id" class="fancy_label">Driver *</label>
+      <%= select_tag :driver_id, options_for_select(@all_drivers, selected: @driver), include_blank: "Select ...", class: "input_text_field",
         "data-driver-target": "driver" %>
     </div>
   <% end %>

--- a/app/views/reservations/_drivers.html.erb
+++ b/app/views/reservations/_drivers.html.erb
@@ -61,7 +61,7 @@
   <% if @reservation.number_of_people_on_trip > 1 %>
     <div class="my-5">
       <%= form.label :backup_driver_id, "Backup Driver", class: "fancy_label" %>
-      <%= form.collection_select :backup_driver_id, @drivers, :id, :display_name, { include_blank: "No Backup Driver" }, class: "input_text_field", "data-action": "driver#hideBackupDriverPhoneField", "data-driver-target": "backup_driver" %>
+      <%= form.collection_select :backup_driver_id, @backup_drivers, :id, :display_name, { include_blank: "No Backup Driver" }, class: "input_text_field", "data-action": "driver#hideBackupDriverPhoneField", "data-driver-target": "backup_driver" %>
     </div>
 
     <div class="error_text" id="backup_driver_error">

--- a/app/views/reservations/_reservation.html.erb
+++ b/app/views/reservations/_reservation.html.erb
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-1 lg:grid-cols-2">
   <div>
     <div class="">
-      <% if is_student?(current_user) && @reservation.approved %>
+      <% if (is_student?(current_user) || is_manager?(current_user)) && @reservation.approved %>
         <p class="body-md-text status-true">
           The reservation is approved by admins
         </p>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -3,7 +3,7 @@
     <%= @reservation.program.unit.name %> Reservation
   </h1>
   <% if is_student?(current_user) && allow_student_to_edit_reservation?(@reservation) || 
-    is_manager?(current_user) && allow_manager_to_edit_reservation?(@reservation)%>
+    is_manager?(current_user) && allow_manager_to_edit_reservation?(@reservation) %>
     <p class="body-md-text mt-2 text-blue-900">
       If you need to edit the reservation, please cancel it and create a new one, 
       or you can email <%= unit_email(@reservation) %> or call the office at: <%= contact_phone(@reservation) %>
@@ -107,20 +107,11 @@
           <% end %>
         <% end %>
         <div class="my-2">
-          <% if @reservation.approved %>
-            <% if is_admin?(current_user) %>
-              <% if @reservation.vehicle_report.present? %>
-                <%= link_to 'Vehicle Report', vehicle_report_path(@reservation.vehicle_report), class: "secondary_blue_button" if @reservation.car.present? %>
-              <% else %>
-                <%= link_to 'New Vehicle Report', new_reservation_vehicle_report_path(@reservation), class: "secondary_blue_button" if @reservation.car.present? %>
-              <% end %>
-            <% end %>
-            <% if is_student?(current_user) && Reservation.no_or_not_complete_vehicle_reports.exists?(@reservation.id) %>
-              <% if @reservation.vehicle_report.present? %>
-                <%= link_to 'Vehicle Report', vehicle_report_path(@reservation.vehicle_report), class: "secondary_blue_button" if @reservation.car.present? %>
-              <% else %>
-                <%= link_to 'New Vehicle Report', new_reservation_vehicle_report_path(@reservation), class: "secondary_blue_button" if @reservation.car.present? %>
-              <% end %>
+          <% if @reservation.approved && allow_add_vehicle_report?(@reservation, current_user) %>
+            <% if @reservation.vehicle_report.present? %>
+              <%= link_to 'Vehicle Report', vehicle_report_path(@reservation.vehicle_report), class: "secondary_blue_button" if @reservation.car.present? %>
+            <% else %>
+              <%= link_to 'New Vehicle Report', new_reservation_vehicle_report_path(@reservation), class: "secondary_blue_button" if @reservation.car.present? %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -37,7 +37,7 @@
     </div>
     <div class="order-first md:order-last">
       <div class="lg:flex lg:flex-col place-items-end whitespace-nowrap">
-        <% if is_admin?(current_user) && !@reservation.approved %>
+        <% if allow_user_to_cancel_reservation?(@reservation) %>
           <% if recurring?(@reservation) %>
             <%= form_tag cancel_recurring_reservation_url, method: :post, local: true,
               data: {
@@ -85,26 +85,6 @@
           <div class="mt-2">
             <%= link_to 'Send Reservation Update', send_reservation_updated_email_path(@reservation), class: "secondary_yellow_button w-1", data: { turbo_confirm: 'Are you sure?', turbo_method: :get} if policy(@reservation).edit? %>
           </div>
-        <% end %>
-        <% if (is_student?(current_user) && allow_student_to_edit_reservation?(@reservation) || is_manager?(current_user) && allow_manager_to_edit_reservation?(@reservation)) && !@reservation.approved %>
-          <% if recurring?(@reservation) %>
-            <%= form_tag cancel_recurring_reservation_url, method: :post, local: true,
-              data: {
-                  approve_target: "form1"
-                } do |form| %>
-              <div class="my-2">
-                <label for="cancel_type" class="fancy_label">Cancel Recurring Reservation</label>
-                <%= select_tag :cancel_type, options_for_select(cancel_types), include_blank: "Select to Cancel ...", class: "filter_select",
-                "data-approve-target": "cancel_type", "data-action": "change->approve#cancelReservation" %>
-              </div>
-            <% end %>
-          <% else %>
-            <%= link_to reservation_path(@reservation), data: { turbo_confirm: 'Are you sure?', turbo_method: :delete} do %>
-              <span class="tertiary_button">Cancel Reservation
-                <i class="fa fa-times" aria-hidden="true"></i>
-              </span>
-            <% end %>
-          <% end %>
         <% end %>
         <div class="my-2">
           <% if @reservation.approved && allow_add_vehicle_report?(@reservation, current_user) %>

--- a/app/views/welcome_pages/_manager_reservations_current.html.erb
+++ b/app/views/welcome_pages/_manager_reservations_current.html.erb
@@ -10,6 +10,7 @@
           <th class="header_th">Drop-off</th>
           <th class="header_th">Site</th>
           <th class="header_th">Car</th>
+          <th class="header_th">Vehicle Report</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +41,19 @@
             </td>
             <td class="mi_tbody_td">
               <%= show_car(reservation) %>
+            </td>
+            <td class="mi_tbody_td">
+              <% if reservation.vehicle_report.present? %>
+                <% if reservation.vehicle_report.approved %>
+                  Approved by admin
+                <% elsif reservation.vehicle_report.student_status %>
+                  Completed
+                <% else %>
+                  <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} if reservation.approved %>
+                <% end %>
+              <% else %>
+                <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.approved %>
+              <% end %>
             </td>
           </tr>
         <% end %>
@@ -85,10 +99,26 @@
             <%= reservation.site.title %>
           </td>
         </tr>
-        <tr class="mobile_tr">
+        <tr class="mi_tbody_tr">
           <th class="header_mobile">Car</th>
           <td class="mi_tbody_td">
             <%= show_car(reservation) %>
+          </td>
+        </tr>
+        <tr class="mobile_tr">
+          <th class="header_mobile">Vehicle Report</th>
+          <td class="mi_tbody_td">
+            <% if reservation.vehicle_report.present? %>
+              <% if reservation.vehicle_report.approved %>
+                Approved by admin
+              <% elsif reservation.vehicle_report.student_status %>
+                Completed
+              <% else %>
+                <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} %>
+              <% end %>
+            <% else %>
+              <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.car.present? %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/welcome_pages/_manager_reservations_future.html.erb
+++ b/app/views/welcome_pages/_manager_reservations_future.html.erb
@@ -10,6 +10,7 @@
           <th class="header_th">Drop-off</th>
           <th class="header_th">Site</th>
           <th class="header_th">Car</th>
+          <th class="header_th">Vehicle Report</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +41,8 @@
             </td>
             <td class="mi_tbody_td">
               <%= show_car(reservation) %>
+            </td>
+            <td>
             </td>
           </tr>
         <% end %>

--- a/app/views/welcome_pages/_manager_reservations_past.html.erb
+++ b/app/views/welcome_pages/_manager_reservations_past.html.erb
@@ -10,6 +10,7 @@
           <th class="header_th">Drop-off</th>
           <th class="header_th">Site</th>
           <th class="header_th">Car</th>
+          <th class="header_th">Vehicle Report</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +41,19 @@
             </td>
             <td class="mi_tbody_td">
               <%= show_car(reservation) %>
+            </td>
+            <td class="mi_tbody_td">
+              <% if reservation.vehicle_report.present? %>
+                <% if reservation.vehicle_report.approved %>
+                  Approved by admin
+                <% elsif reservation.vehicle_report.student_status %>
+                  Completed
+                <% else %>
+                  <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} %>
+                <% end %>
+              <% else %>
+                <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.car.present? %>
+              <% end %>
             </td>
           </tr>
         <% end %>
@@ -85,10 +99,26 @@
             <%= reservation.site.title %>
           </td>
         </tr>
-        <tr class="mobile_tr">
+        <tr class="mi_tbody_tr">
           <th class="header_mobile">Car</th>
           <td class="mi_tbody_td">
             <%= show_car(reservation) %>
+          </td>
+        </tr>
+        <tr class="mobile_tr">
+          <th class="header_mobile">Vehicle Report</th>
+          <td class="mi_tbody_td">
+            <% if reservation.vehicle_report.present? %>
+              <% if reservation.vehicle_report.approved %>
+                Approved by admin
+              <% elsif reservation.vehicle_report.student_status %>
+                Completed
+              <% else %>
+                <%= link_to 'Vehicle report', vehicle_report_path(reservation.vehicle_report), class: "link_to", data: {turbo_frame: "_top"} %>
+              <% end %>
+            <% else %>
+              <%= link_to 'New vehicle report', new_reservation_vehicle_report_path(reservation), class: "link_to", data: {turbo_frame: "_top"} if reservation.car.present? %>
+            <% end %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
If admins create reservations or edit drivers they can assign managers/instructors to be drivers.

- Managers/instructors should be eligible drivers to be on the list of drivers.
- Managers/instructors can not be backup drivers.
- Managers or students can't assign managers/instructors to be drivers.

To test
login as an admin in one window and as a manager (um180079) in another 
- check that the unit has managers who are eligible drivers including um180079
- check that there is a program where the instructor can be a driver
- check that there is a program with managers who can be drivers
- create a reservation for that program
- when adding drivers notice that the list of drivers contains managers/instructor
- make um180079 a driver
- finish creating the reservation
  - in a window where um180079 is logged in check that this reservation is available to view
- edit the reservation 
  - notice that you can reassign a driver to be a student
   - in a window where um180079 is logged in check that this reservation is not available anymore
- edit the reservation 
  - notice that you can reassign a driver to be a manager


