### PR TITLE
Lra 787 lsa ride share allow drivers to edit passengers all the time

### DIFF
--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -55,11 +55,13 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def is_program_manager?
-    @record.all_managers.include?(@user.uniqname)
+    program = Program.find(params[:id])
+    program.all_managers.include?(@user.uniqname)
   end
 
   def is_instructor?
-    @record.instructor.uniqname == @user.uniqname
+    program = Program.find(params[:id])
+    program.instructor.uniqname == @user.uniqname
   end
 
 end

--- a/app/policies/student_policy.rb
+++ b/app/policies/student_policy.rb
@@ -3,7 +3,7 @@
 class StudentPolicy < ApplicationPolicy
 
   def index?
-    user_in_access_group?
+    user_in_access_group? || is_program_manager?
   end
 
   def show?
@@ -52,6 +52,11 @@ class StudentPolicy < ApplicationPolicy
 
   def destroy?
     user_in_access_group?
+  end
+
+  def is_program_manager?
+    program = Program.find(params[:program_id])
+    program.all_managers.include?(@user.uniqname)
   end
 
 end

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -12,7 +12,7 @@
               <%= link_to 'Edit Program', program_data_path(@program), class: "primary_button" %>
             </div>
           <% end %>
-          <% if policy(Student).update_student_list? %>
+          <% if policy(Program).show? %>
             <div class="py-2">
               <%= link_to 'Students List', program_students_path(@program), class: "secondary_blue_button" %>
             </div>

--- a/app/views/programs/students/_student_list.html.erb
+++ b/app/views/programs/students/_student_list.html.erb
@@ -18,12 +18,16 @@
       <tbody>
         <% @students.each do |student| %>
           <tr class="mi_tbody_tr">
-            <td class="mi_tbody_td">
-              <%= link_to "View", program_student_path(@student_program, student), class: "link_to", data: {turbo_frame: "_top"} %>
-            </td>
-            <td class="mi_tbody_td">
-              <%= link_to 'Edit', edit_program_student_path(@student_program, student), class: "link_to", data: {turbo_frame: "_top"} %>
-            </td>
+            <% if policy(Student).update_student_list? %>
+              <td class="mi_tbody_td">
+                <%= link_to "View", program_student_path(@student_program, student), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+              <td class="mi_tbody_td">
+                <%= link_to 'Edit', edit_program_student_path(@student_program, student), class: "link_to", data: {turbo_frame: "_top"} %>
+              </td>
+            <% else %>
+              <td></td><td></td>
+            <% end %>
             <td class="mi_tbody_td">
               <% if student.registered %>
                 <i class="fa-solid fa-check"></i>

--- a/app/views/reservations/_reservation.html.erb
+++ b/app/views/reservations/_reservation.html.erb
@@ -71,7 +71,7 @@
           <%= show_driver(reservation) %>
         </p>
       </div>
-      <% if ((is_admin?(current_user) && @reservation.end_time > DateTime.now) || allow_student_to_edit_reservation?(@reservation) || allow_manager_to_edit_reservation?(@reservation)) %>
+      <% if (is_admin?(current_user) || allow_student_to_edit_drivers?(@reservation) || allow_manager_to_edit_drivers?(@reservation)) %>
         <div class="py-2 whitespace-nowrap">
           <%= link_to add_drivers_path(@reservation, :edit => true) do %>
             <span class="tertiary_button"> 
@@ -134,7 +134,7 @@
       <p class="body-lg-bold-text">
         Passengers (<%= @reservation.passengers.count %>):
       </p>
-      <% if ((is_admin?(current_user) && @reservation.end_time > DateTime.now) || allow_student_to_edit_reservation?(@reservation) || allow_manager_to_edit_reservation?(@reservation)) %>
+      <% if (is_admin?(current_user) || allow_student_to_edit_passengers?(@reservation) || allow_manager_to_edit_passengers?(@reservation)) %>
         <div class="py-2">
           <div>
             <%= link_to add_passengers_path(@reservation, :edit => true) do %>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -2,8 +2,8 @@
   <h1>
     <%= @reservation.program.unit.name %> Reservation
   </h1>
-  <% if is_student?(current_user) && allow_student_to_edit_reservation?(@reservation) || 
-    is_manager?(current_user) && allow_manager_to_edit_reservation?(@reservation) %>
+  <% if is_student?(current_user) && allow_student_to_edit_drivers?(@reservation) || 
+    is_manager?(current_user) && allow_manager_to_edit_drivers?(@reservation) %>
     <p class="body-md-text mt-2 text-blue-900">
       If you need to edit the reservation, please cancel it and create a new one, 
       or you can email <%= unit_email(@reservation) %> or call the office at: <%= contact_phone(@reservation) %>


### PR DESCRIPTION
1. Give drivers permission to edit passengers until reservation.end_time + one hour.
Drivers might be students or managers.

2. Also, give managers permission to see (but not edit) student lists for their programs.

To test (1)

- log in as an admin, student (um174887), and faculty(um180079): 
- create a reservation where the manager is a driver and the student is a backup driver
- reservation should start today and end no earlier than 55 minutes before now
- check that all users can edit passengers
- wait until the current time < reservation.end_time + 1.hour (or edit the reservation as an admin)
- check that the admin can edit passengers
- check that drivers can not edit managers
 
To test (2)
- in the manager window go to programs and check that student lists are available
- check that the manager can see only the index view for students, Edit and View links are not available
- compare with admin's view
