### PR TITLE
Lra 779 lsa ride share improve update mvr status for managers

### DIFF
--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -42,10 +42,10 @@ class ManagersController < ApplicationController
       else
         unit_ids = current_user.unit_ids
       end
-      p = Program.where(unit_id: unit_ids)
-      i_ids = p.pluck(:instructor_id).uniq
+      programs = Program.where(unit_id: unit_ids)
+      i_ids = programs.pluck(:instructor_id).uniq
       instructors = Manager.where(id: i_ids)
-      p_ids = p.pluck(:id)
+      p_ids = programs.pluck(:id)
       managers = Manager.joins(:programs).where('managers_programs.program_id IN (?)', p_ids)
       @managers = (instructors + managers).uniq.sort_by(&:uniqname)
       authorize Manager

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -23,7 +23,7 @@ class ManagersController < ApplicationController
     @managers.each do |manager|
       status = mvr_status(manager.uniqname)
       unless manager.update(mvr_status: status)
-        redirect_to managers_path(@managers), alert: "Error updating student record."
+        redirect_to managers_path, alert: "Error updating manager record."
       end
     end
     flash.now[:notice] = "MVR status is updated."


### PR DESCRIPTION
Managers controller: update MVR status only for the selected unit or current_user's unit(s), not for all managers.

Refactor some code too.