### PR TITLE
fix time in today reservation list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -195,9 +195,9 @@ module ApplicationHelper
 
   def show_day_reservation_time(reservation)
     if reservation.start_time.to_date == reservation.end_time.to_date 
-      show_time(reservation.start_time) + " - " +  show_time(reservation.end_time)
+      show_time(reservation.start_time + 15.minute) + " - " +  show_time(reservation.end_time - 15.minute)
     else
-      show_date_time(reservation.start_time) + " - " +  show_date_time(reservation.end_time)
+      show_date_time(reservation.start_time + 15.minute) + " - " +  show_date_time(reservation.end_time - 15.minute)
     end
   end
   


### PR DESCRIPTION
Today List (reservations index calendar) shows the start and end time from the reservation table which is 15 minutes earlier and later than the real reservation's time.
The pull request edited the helper method show_day_reservation_time to adjust start and end times on the Today List page.
