### PR TITLE
Fix student roster api output format

### DIFF
--- a/app/controllers/concerns/student_api.rb
+++ b/app/controllers/concerns/student_api.rb
@@ -67,6 +67,11 @@ module StudentApi
         if result['success']
           if result['data']['Classes']['Class']['ClassSections']['ClassSection']['ClassStudents'].present?
             data = result['data']['Classes']['Class']['ClassSections']['ClassSection']['ClassStudents']['ClassStudent']
+            if data.class == Hash
+              data1 = []
+              data1 << data
+              data = data1
+            end
             students_in_db_registered = program.students.registered.where(course_id: course.id).pluck(:uniqname)
             students_in_db_added_manually = program.students.added_manually.pluck(:uniqname)
             data.each do |student_info|

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -21,6 +21,7 @@ class Course < ApplicationRecord
   end
 
   def upcase_subject
+    self.subject = subject.strip
     self.subject = subject.upcase
   end
 


### PR DESCRIPTION
If the API returns one student the output data has a Hash format.
If there are many students the output data has an Array of Hashes format.
Convert a hash into an Array with one element. 

